### PR TITLE
Make sorting in browser optional

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -181,7 +181,8 @@
 ## Note: Below variables are used for sorting songs in browser.
 ## The sort mode determines how songs are sorted, and can be used
 ## in combination with a sort format to specify a custom sorting format.
-## Possible values for browser_sort_mode are "name", "mtime" and "format".
+## Possible values for browser_sort_mode are "name", "mtime", "format"
+## and "unsorted".
 ##
 #
 #browser_sort_mode = "name"

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -133,7 +133,7 @@ Format for albums' list in Tag editor.
 Song format for window title.
 .TP
 .B browser_sort_mode
-Determines sort mode for browser. Possible values are "name", "mtime" and "format".
+Determines sort mode for browser. Possible values are "name", "mtime", "format" and "unsorted".
 .TP
 .B browser_sort_format
 Format to use for sorting songs in browser. For this option to be effective, browser_sort_mode must be set to "format".

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1973,12 +1973,17 @@ void ToggleBrowserSortMode::run()
 			Statusbar::msg("Sort songs by: Custom format");
 			break;
 		case smCustomFormat:
+			Config.browser_sort_mode = smUnsorted;
+			Statusbar::msg("Sort songs by: Unsorted");
+			break;
+		case smUnsorted:
 			Config.browser_sort_mode = smName;
 			Statusbar::msg("Sort songs by: Name");
 			break;
 	}
-	std::sort(myBrowser->main().begin()+(myBrowser->CurrentDir() != "/"), myBrowser->main().end(),
-		LocaleBasedItemSorting(std::locale(), Config.ignore_leading_the, Config.browser_sort_mode));
+	if (Config.browser_sort_mode != smUnsorted)
+		std::sort(myBrowser->main().begin()+(myBrowser->CurrentDir() != "/"), myBrowser->main().end(),
+			LocaleBasedItemSorting(std::locale(), Config.ignore_leading_the, Config.browser_sort_mode));
 }
 
 bool ToggleLibraryTagType::canBeRun() const

--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -423,7 +423,7 @@ void Browser::GetDirectory(std::string dir, std::string subdir)
 #	else
 	list = Mpd.GetDirectory(dir);
 #	endif // !WIN32
-	if (!isLocal()) // local directory is already sorted
+	if (Config.browser_sort_mode != smUnsorted && !isLocal()) // local directory is already sorted
 		std::sort(list.begin(), list.end(),
 			LocaleBasedItemSorting(std::locale(), Config.ignore_leading_the, Config.browser_sort_mode));
 	
@@ -505,8 +505,9 @@ void Browser::GetLocalDirectory(MPD::ItemList &v, const std::string &directory, 
 		}
 	});
 	
-	std::sort(v.begin()+start_size, v.end(), LocaleBasedItemSorting(std::locale(),
-		Config.ignore_leading_the, Config.browser_sort_mode));
+	if (Config.browser_sort_mode != smUnsorted)
+		std::sort(v.begin()+start_size, v.end(), LocaleBasedItemSorting(std::locale(),
+			Config.ignore_leading_the, Config.browser_sort_mode));
 }
 
 void Browser::ClearDirectory(const std::string &path) const

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -810,6 +810,8 @@ void Configuration::Read()
 					browser_sort_mode = smMTime;
 				else if (v == "format")
 					browser_sort_mode = smCustomFormat;
+				else if (v == "unsorted")
+					browser_sort_mode = smUnsorted;
 				else
 					browser_sort_mode = smName; // "name" or invalid
 			}

--- a/src/settings.h
+++ b/src/settings.h
@@ -30,7 +30,7 @@
 
 struct BaseScreen; // forward declaration for screens sequence
 
-enum SortMode { smName, smMTime, smCustomFormat };
+enum SortMode { smName, smMTime, smCustomFormat, smUnsorted };
 
 struct Column
 {


### PR DESCRIPTION
This adds a new option, "unsorted", to browser_sort_mode. If this mode
is selected, no sorting is done in the browser view, and the elements
are shown in the same order as received from the MPD server.

This is desirable because the MPD server may list the elements in a significant order which is different from the sort modes of ncmpcpp. An example is mopidy with mopidy-spotify, where the playlists are listed in the same order as they are sorted in Spotify. This change makes it possible to view them in that order in ncmpcpp.
