### PR TITLE
Fix crossfade being shown in status when other options are being toggled

### DIFF
--- a/src/status.cpp
+++ b/src/status.cpp
@@ -288,7 +288,7 @@ void Status::update(int event)
 				if (m_status_initialized)
 					Statusbar::printf("Consume mode is %1%", !m_consume ? "off" : "on");
 			}
-			if (('x' == m_crossfade) != st.crossfade())
+			if (('x' == m_crossfade) != (st.crossfade() != 0))
 			{
 				int crossfade = st.crossfade();
 				m_crossfade = crossfade ? 'x' : 0;


### PR DESCRIPTION
st.crossfade() returns a integer rather than a boolean so this was causing the crossfade update message to appear in the statusbar when other options were being toggled.
