### PR TITLE
Fix Floating point exception when adding tags.size() random tags

### DIFF
--- a/src/mpdpp.cpp
+++ b/src/mpdpp.cpp
@@ -531,7 +531,7 @@ bool Connection::AddRandomTag(mpd_tag_type tag, size_t number)
 		return false;
 
 	std::random_shuffle(tags.begin(), tags.end());
-	auto it = tags.begin()+rand()%(tags.size()-number);
+    auto it = tags.begin();
 	for (size_t i = 0; i < number && it != tags.end(); ++i)
 	{
 		StartSearch(true);

--- a/src/mpdpp.cpp
+++ b/src/mpdpp.cpp
@@ -531,7 +531,7 @@ bool Connection::AddRandomTag(mpd_tag_type tag, size_t number)
 		return false;
 
 	std::random_shuffle(tags.begin(), tags.end());
-    auto it = tags.begin();
+	auto it = tags.begin();
 	for (size_t i = 0; i < number && it != tags.end(); ++i)
 	{
 		StartSearch(true);


### PR DESCRIPTION
Just a small bugfix.
I don't know why the iterator is advanced to a random position since the vector is previously shuffled, but this creates a floating point exception when trying to add e.g. 10 random albums from a library that has exactly 10 albums. 
If this is actually useful (don't see why but who knows), perhaps do like in AddRandomSongs (line 574) and use rand() % max(1, tags.size()-number).