### PR TITLE
Add support for multikey key bindings.

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -527,3 +527,5 @@
 #
 #active_window_border = red
 #
+#keybinding_timeout = 500
+#

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -30,6 +30,11 @@ BindingsConfiguration Bindings;
 
 Key Key::noOp = Key(ERR, NCurses);
 
+bool operator==(const KeySequence &k1, const KeySequence &k2) {
+    return k1.sequence == k2.sequence;
+    return true;
+}
+
 namespace {
 
 Key stringToSpecialKey(const std::string &s)
@@ -90,6 +95,17 @@ Key stringToKey(const std::string &s)
 			result = Key(ws[0], Key::Standard);
 	}
 	return result;
+}
+
+KeySequence stringToKeySequence(const std::string &s)
+{
+	std::vector<Key> sequence;
+	for (auto c : s)
+	{
+		std::string x(&c, 1);
+		sequence.push_back(stringToKey(x));
+	}
+	return KeySequence(sequence);
 }
 
 template <typename F>
@@ -214,7 +230,7 @@ bool BindingsConfiguration::read(const std::string &file)
 	Binding::ActionChain actions;
 	
 	// def_key specific variables
-	Key key = Key::noOp;
+	KeySequence keySequence;
 	std::string strkey;
 	
 	// def_command specific variables
@@ -247,7 +263,7 @@ bool BindingsConfiguration::read(const std::string &file)
 		{
 			if (!actions.empty())
 			{
-				bind(key, actions);
+				bind(keySequence, actions);
 				actions.clear();
 				return true;
 			}
@@ -304,8 +320,8 @@ bool BindingsConfiguration::read(const std::string &file)
 				break;
 			in_progress = InProgress::Key;
 			strkey = getEnclosedString(line, '"', '"', 0);
-			key = stringToKey(strkey);
-			if (key == Key::noOp)
+			keySequence = stringToKeySequence(strkey);
+			if (keySequence.empty())
 			{
 				error() << "invalid key: '" << strkey << "'\n";
 				break;

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -32,7 +32,6 @@ Key Key::noOp = Key(ERR, NCurses);
 
 bool operator==(const KeySequence &k1, const KeySequence &k2) {
     return k1.sequence == k2.sequence;
-    return true;
 }
 
 namespace {

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -159,13 +159,13 @@ public:
 
 	size_t hash() const
 	{
-		size_t h = 0;
+		size_t hash = 5381;
 		for (auto k : sequence)
 		{
-			h <<= 16;
-			h |= (k.getChar() << 1) | (k.getType() == Key::Standard);
+			auto value = (k.getChar() << 1) | (k.getType() == Key::Standard);
+			hash = ((hash << 5) + hash) + value;
 		}
-		return h;
+		return hash;
 	}
 
 	std::string toString(bool *print_backspace) const

--- a/src/bindings.h
+++ b/src/bindings.h
@@ -23,10 +23,12 @@
 
 #include <algorithm>
 #include <boost/bind.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cassert>
 #include <unordered_map>
 #include "actions.h"
 #include "macro_utilities.h"
+#include "utility/wide_string.h"
 
 /// Key for binding actions to it. Supports non-ascii characters.
 struct Key
@@ -118,6 +120,131 @@ private:
 	bool m_immediate;
 };
 
+class KeySequence
+{
+protected:
+	std::vector<Key> sequence;
+
+public:
+	KeySequence() { }
+
+	KeySequence(std::vector<Key> sequence) : sequence(std::move(sequence)) { }
+
+	KeySequence(const Key &key)
+	{
+		sequence.push_back(key);
+	}
+
+	bool startsWith(const KeySequence &ks) const
+	{
+		if (ks.count() > count())
+			return false;
+		for (auto i = 0, e = ks.count(); i < e; ++i)
+		{
+			if (sequence[i] != ks.sequence[i])
+				return false;
+		}
+		return true;
+	}
+
+	bool empty() const
+	{
+		return sequence.empty();
+	}
+
+	int count() const
+	{
+		return sequence.size();
+	}
+
+	size_t hash() const
+	{
+		size_t h = 0;
+		for (auto k : sequence)
+		{
+			h <<= 16;
+			h |= (k.getChar() << 1) | (k.getType() == Key::Standard);
+		}
+		return h;
+	}
+
+	std::string toString(bool *print_backspace) const
+	{
+		std::string result;
+		for (auto key : sequence) {
+			if (key == Key(KEY_UP, Key::NCurses))
+				result += "Up";
+			else if (key == Key(KEY_DOWN, Key::NCurses))
+				result += "Down";
+			else if (key == Key(KEY_PPAGE, Key::NCurses))
+				result += "Page Up";
+			else if (key == Key(KEY_NPAGE, Key::NCurses))
+				result += "Page Down";
+			else if (key == Key(KEY_HOME, Key::NCurses))
+				result += "Home";
+			else if (key == Key(KEY_END, Key::NCurses))
+				result += "End";
+			else if (key == Key(KEY_SPACE, Key::Standard))
+				result += "Space";
+			else if (key == Key(KEY_ENTER, Key::Standard))
+				result += "Enter";
+			else if (key == Key(KEY_IC, Key::NCurses))
+				result += "Insert";
+			else if (key == Key(KEY_DC, Key::NCurses))
+				result += "Delete";
+			else if (key == Key(KEY_RIGHT, Key::NCurses))
+				result += "Right";
+			else if (key == Key(KEY_LEFT, Key::NCurses))
+				result += "Left";
+			else if (key == Key(KEY_TAB, Key::Standard))
+				result += "Tab";
+			else if (key == Key(KEY_SHIFT_TAB, Key::NCurses))
+				result += "Shift-Tab";
+			else if (key >= Key(KEY_CTRL_A, Key::Standard) && key <= Key(KEY_CTRL_Z, Key::Standard))
+			{
+				result += "Ctrl-";
+				result += key.getChar()+64;
+			}
+			else if (key >= Key(KEY_F1, Key::NCurses) && key <= Key(KEY_F12, Key::NCurses))
+			{
+				result += "F";
+				result += boost::lexical_cast<std::string>(key.getChar()-264);
+			}
+			else if ((key == Key(KEY_BACKSPACE, Key::NCurses) || key == Key(KEY_BACKSPACE_2, Key::Standard)))
+			{
+				// since some terminals interpret KEY_BACKSPACE as backspace and other need KEY_BACKSPACE_2,
+				// actions have to be bound to either of them, but we want to display "Backspace" only once,
+				// hance this 'print_backspace' switch.
+				if (!print_backspace || *print_backspace)
+				{
+					result += "Backspace";
+					if (print_backspace)
+						*print_backspace = false;
+				}
+			}
+			else
+				result += ToString(std::wstring(1, key.getChar()));
+		}
+		return result;
+	}
+
+	friend bool operator==(const KeySequence &k1, const KeySequence &k2);
+};
+
+class MutableKeySequence : public KeySequence
+{
+public:
+	void append(const Key &key)
+	{
+		sequence.push_back(key);
+	}
+
+	void reset()
+	{
+		sequence.clear();
+	}
+};
+
 /// Keybindings configuration
 class BindingsConfiguration
 {
@@ -125,9 +252,12 @@ class BindingsConfiguration
 		size_t operator()(const Key &k) const {
 			return (k.getChar() << 1) | (k.getType() == Key::Standard);
 		}
+		size_t operator()(const KeySequence &ks) const {
+            return ks.hash();
+		}
 	};
 	typedef std::unordered_map<std::string, Command> CommandsSet;
-	typedef std::unordered_map<Key, std::vector<Binding>, KeyHash> BindingsMap;
+	typedef std::unordered_map<KeySequence, std::vector<Binding>, KeyHash> BindingsMap;
 	
 public:
 	typedef BindingsMap::value_type::second_type::iterator BindingIterator;
@@ -145,8 +275,12 @@ public:
 	}
 	
 	std::pair<BindingIterator, BindingIterator> get(const Key &k) {
+		return get(KeySequence(k));
+	}
+
+	std::pair<BindingIterator, BindingIterator> get(const KeySequence &ks) {
 		std::pair<BindingIterator, BindingIterator> result;
-		auto it = m_bindings.find(k);
+		auto it = m_bindings.find(ks);
 		if (it != m_bindings.end()) {
 			result.first = it->second.begin();
 			result.second = it->second.end();
@@ -157,18 +291,38 @@ public:
 		}
 		return result;
 	}
-	
+
 	BindingsMap::const_iterator begin() const { return m_bindings.begin(); }
 	BindingsMap::const_iterator end() const { return m_bindings.end(); }
+
+	std::vector<KeySequence> getPrefix(KeySequence &ks)
+	{
+		std::vector<KeySequence> prefixSet;
+		for (auto s : m_bindings) {
+			if (s.first.startsWith(ks)) {
+				prefixSet.push_back(ks);
+			}
+		}
+		return prefixSet;
+	}
 	
 private:
 	bool notBound(const Key &k) const {
 		return k != Key::noOp && m_bindings.find(k) == m_bindings.end();
 	}
+
+	bool notBound(const KeySequence &ks) const {
+		return !ks.empty() && m_bindings.find(ks) == m_bindings.end();
+	}
 	
 	template <typename ArgT>
 	void bind(Key k, ArgT &&t) {
-		m_bindings[k].push_back(std::forward<ArgT>(t));
+		m_bindings[KeySequence(k)].push_back(std::forward<ArgT>(t));
+	}
+
+	template <typename ArgT>
+	void bind(KeySequence ks, ArgT &&t) {
+		m_bindings[ks].push_back(std::forward<ArgT>(t));
 	}
 	
 	BindingsMap m_bindings;

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -36,62 +36,9 @@ Help *myHelp;
 
 namespace {
 
-std::string key_to_string(const Key &key, bool *print_backspace)
+std::string key_to_string(const KeySequence &ks, bool *print_backspace)
 {
-	std::string result;
-	if (key == Key(KEY_UP, Key::NCurses))
-		result += "Up";
-	else if (key == Key(KEY_DOWN, Key::NCurses))
-		result += "Down";
-	else if (key == Key(KEY_PPAGE, Key::NCurses))
-		result += "Page Up";
-	else if (key == Key(KEY_NPAGE, Key::NCurses))
-		result += "Page Down";
-	else if (key == Key(KEY_HOME, Key::NCurses))
-		result += "Home";
-	else if (key == Key(KEY_END, Key::NCurses))
-		result += "End";
-	else if (key == Key(KEY_SPACE, Key::Standard))
-		result += "Space";
-	else if (key == Key(KEY_ENTER, Key::Standard))
-		result += "Enter";
-	else if (key == Key(KEY_IC, Key::NCurses))
-		result += "Insert";
-	else if (key == Key(KEY_DC, Key::NCurses))
-		result += "Delete";
-	else if (key == Key(KEY_RIGHT, Key::NCurses))
-		result += "Right";
-	else if (key == Key(KEY_LEFT, Key::NCurses))
-		result += "Left";
-	else if (key == Key(KEY_TAB, Key::Standard))
-		result += "Tab";
-	else if (key == Key(KEY_SHIFT_TAB, Key::NCurses))
-		result += "Shift-Tab";
-	else if (key >= Key(KEY_CTRL_A, Key::Standard) && key <= Key(KEY_CTRL_Z, Key::Standard))
-	{
-		result += "Ctrl-";
-		result += key.getChar()+64;
-	}
-	else if (key >= Key(KEY_F1, Key::NCurses) && key <= Key(KEY_F12, Key::NCurses))
-	{
-		result += "F";
-		result += boost::lexical_cast<std::string>(key.getChar()-264);
-	}
-	else if ((key == Key(KEY_BACKSPACE, Key::NCurses) || key == Key(KEY_BACKSPACE_2, Key::Standard)))
-	{
-		// since some terminals interpret KEY_BACKSPACE as backspace and other need KEY_BACKSPACE_2,
-		// actions have to be bound to either of them, but we want to display "Backspace" only once,
-		// hance this 'print_backspace' switch.
-		if (!print_backspace || *print_backspace)
-		{
-			result += "Backspace";
-			if (print_backspace)
-				*print_backspace = false;
-		}
-	}
-	else
-		result += ToString(std::wstring(1, key.getChar()));
-	return result;
+	return ks.toString(print_backspace);
 }
 
 std::string display_keys(const Actions::Type at)

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -144,6 +144,8 @@ int main(int argc, char **argv)
 
 	// local variables
 	bool key_pressed = false;
+	MutableKeySequence command;
+	auto last_key_press = boost::posix_time::from_time_t(0);
 	Key input = Key::noOp;
 	auto connect_attempt = boost::posix_time::from_time_t(0);
 	auto past = boost::posix_time::from_time_t(0);
@@ -211,7 +213,18 @@ int main(int argc, char **argv)
 			key_pressed = input != Key::noOp;
 			
 			if (!key_pressed)
+			{
+				// Timeout on keybinding. Execute the last matched binding.
+				if (!command.empty()
+				&& ((Timer - last_key_press) > Config.keybinding_timeout))
+				{
+					// Use this binding.
+					auto k = Bindings.get(command);
+					std::any_of(k.first, k.second, boost::bind(&Binding::execute, _1));
+					command.reset();
+				}
 				continue;
+			}
 
 			// The reason we want to update timer here is that if the timer is updated
 			// in Status::trace, then Key::read usually blocks for 500ms and if key is
@@ -221,10 +234,27 @@ int main(int argc, char **argv)
 			// timer in Status::trace only if there was no recent input.
 			Timer = boost::posix_time::microsec_clock::local_time();
 
+
 			try
 			{
-				auto k = Bindings.get(input);
-				std::any_of(k.first, k.second, boost::bind(&Binding::execute, _1));
+				command.append(input);
+				std::vector<KeySequence> sequences = Bindings.getPrefix(command);
+				if (sequences.size() == 1)
+				{
+					if (sequences.front() == command)
+					{
+						// Use this binding.
+						auto k = Bindings.get(command);
+						std::any_of(k.first, k.second, boost::bind(&Binding::execute, _1));
+						command.reset();
+					}
+				}
+				else if (!sequences.empty())
+				{
+					// There is more than one binding prefixed with the current
+					// command. Wait for a timeout to register.
+					last_key_press = Timer;
+				}
 			}
 			catch (ConversionError &e)
 			{

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -668,6 +668,10 @@ bool Configuration::read(const std::vector<std::string> &config_paths)
 	p.add("active_window_border", border(
 		active_window_border, NC::Color::Red
 	));
+	p.add("keybinding_timeout", assign_default<unsigned>(
+		keybinding_timeout, 500, [](unsigned v) {
+			return boost::posix_time::milliseconds(v);
+	}));
 
 	return std::all_of(
 		config_paths.begin(),

--- a/src/settings.h
+++ b/src/settings.h
@@ -50,7 +50,8 @@ struct Column
 struct Configuration
 {
 	Configuration()
-	: playlist_disable_highlight_delay(0), visualizer_sync_interval(0)
+	: playlist_disable_highlight_delay(0), visualizer_sync_interval(0),
+	  keybinding_timeout(0)
 	{ }
 
 	bool read(const std::vector<std::string> &config_paths);
@@ -192,6 +193,8 @@ struct Configuration
 	std::list<ScreenType> screen_sequence;
 
 	SortMode browser_sort_mode;
+
+	boost::posix_time::milliseconds keybinding_timeout;
 };
 
 extern Configuration Config;


### PR DESCRIPTION
My C++ is a little rusty, but here is support for what was requestedin issue #24. It works in the same way as vim's multikey bindings.
- Defaults to a 500ms timeout. On timeout, it will execute the full command if there was one matching, otherwise it will do nothing.
  - Example 1: 'g' and 'gg' both bound. 'g' is pressed, and on timeout, 'g' binding would be executed. If a 2nd 'g' is pressed before timeout, binding for 'gg' will be executed immediately.
  - Example 2: 'g' and 'gg' both bound. 'g' is pressed, and before timeout, 'z' is pressed. Since 'gz' is not bound, nothing is executed. Since no commands have a prefix of 'gz', there is no further timeout, and the next command can be started immediately.
- Config file support with "keybinding_timeout".
- Bindings config file support.
- Properly listed in help screen.

Please let me know where I can improve this patch.

I would also like to add a small area in the status bar that lists the currently buffered command. But I will leave that for later.