### PR TITLE
Adding lorenz visualizer

### DIFF
--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -183,6 +183,9 @@ std::ostream &operator<<(std::ostream& os, VisualizerType vt)
 		case VisualizerType::Ellipse:
 			os << "sound ellipse";
 			break;
+		case VisualizerType::Lorenz:
+			os << "sound lorenz";
+			break;
 	}
 	return os;
 }
@@ -201,6 +204,8 @@ std::istream &operator>>(std::istream& is, VisualizerType &vt)
 #	endif // HAVE_FFTW3_H
 	else if (svt == "ellipse")
 		vt = VisualizerType::Ellipse;
+	else if (svt == "lorenz")
+		vt = VisualizerType::Lorenz;
 	else
 		is.setstate(std::ios::failbit);
 	return is;

--- a/src/enums.h
+++ b/src/enums.h
@@ -50,7 +50,8 @@ enum class VisualizerType {
 #	ifdef HAVE_FFTW3_H
 	Spectrum,
 #	endif // HAVE_FFTW3_H
-	Ellipse
+	Ellipse,
+	Lorenz
 };
 std::ostream &operator<<(std::ostream &os, VisualizerType vt);
 std::istream &operator>>(std::istream &is, VisualizerType &vt);

--- a/src/visualizer.cpp
+++ b/src/visualizer.cpp
@@ -400,8 +400,8 @@ void Visualizer::DrawSoundLorenz(int16_t *buf, ssize_t samples, size_t, size_t h
 	DrawSoundLorenzStereo(buf, buf, samples, height/2);
 }
 
-double rotation_count_left = 0;
-double rotation_count_right = 0;
+double lorenz_rotation_count_left = 0;
+double lorenz_rotation_count_right = 0;
 
 void Visualizer::DrawSoundLorenzStereo(int16_t *buf_left, int16_t *buf_right, ssize_t samples, size_t half_height)
 {
@@ -409,8 +409,8 @@ void Visualizer::DrawSoundLorenzStereo(int16_t *buf_left, int16_t *buf_right, ss
 	double lorenz_a = 10.0;
 	double lorenz_c = 8.0 / 3.0;
 
-	rotation_count_left = rotation_count_left >= 1000.0 ? 0 : rotation_count_left;
-	rotation_count_right = rotation_count_right >= 1000.0 ? 0 : rotation_count_right;
+	lorenz_rotation_count_left = lorenz_rotation_count_left >= 1000.0 ? 0 : lorenz_rotation_count_left;
+	lorenz_rotation_count_right = lorenz_rotation_count_right >= 1000.0 ? 0 : lorenz_rotation_count_right;
 
 	double win_width = w.getWidth();
 	double height = half_height;
@@ -446,10 +446,10 @@ void Visualizer::DrawSoundLorenzStereo(int16_t *buf_left, int16_t *buf_right, ss
 	//Approximately the first 100 points of the lorenz are usually outliers from the main body of the lorenz, so multiplying by 1.25
 	//adjusts the bounds so that the main body takes up most of the height of the screen.
 	//Only consider max y coordinate since both max z and max x will be much smaller than the max y.
-	double scaling_multiplier = 1.25 * (height)/sqrt(lorenz_c * lorenz_b * lorenz_b - pow(z_center-lorenz_b,2)/pow(lorenz_b,2));
+	double scaling_multiplier = 2.0 * height/sqrt(lorenz_c * pow(lorenz_b,2) - pow(z_center-lorenz_b,2)/pow(lorenz_b,2));
 
-	double rotation_angle_x = ( rotation_count_left * 2.0 * boost::math::constants::pi<double>() ) / 1000.0;
-	double rotation_angle_y = ( rotation_count_right * 2.0 * boost::math::constants::pi<double>() ) / 1000.0;
+	double rotation_angle_x = ( lorenz_rotation_count_left * boost::math::constants::pi<double>() ) / 500.0;
+	double rotation_angle_y = ( lorenz_rotation_count_right * boost::math::constants::pi<double>() ) / 500.0;
 
 	double deg_multiplier_cos_x = std::cos(rotation_angle_x);
 	double deg_multiplier_sin_x = std::sin(rotation_angle_x);
@@ -499,8 +499,12 @@ void Visualizer::DrawSoundLorenzStereo(int16_t *buf_left, int16_t *buf_right, ss
 		}
 	}
 
-	rotation_count_left += rotation_interval_left;
-	rotation_count_right += rotation_interval_right;
+	//cap the rotation speed at pi so that it doesn't spin too fast
+	rotation_interval_left = std::min(rotation_interval_left, boost::math::constants::pi<double>());
+	rotation_interval_right = std::min(rotation_interval_right, boost::math::constants::pi<double>());
+
+	lorenz_rotation_count_left += rotation_interval_left;
+	lorenz_rotation_count_right += rotation_interval_right;
 }
 
 /**********************************************************************/

--- a/src/visualizer.h
+++ b/src/visualizer.h
@@ -70,6 +70,8 @@ private:
 	void DrawSoundWaveFillStereo(int16_t *, int16_t *, ssize_t, size_t);
 	void DrawSoundEllipse(int16_t *, ssize_t, size_t, size_t);
 	void DrawSoundEllipseStereo(int16_t *, int16_t *, ssize_t, size_t);
+	void DrawSoundLorenz(int16_t *, ssize_t, size_t, size_t);
+	void DrawSoundLorenzStereo(int16_t *, int16_t *, ssize_t, size_t);
 #	ifdef HAVE_FFTW3_H
 	void DrawFrequencySpectrum(int16_t *, ssize_t, size_t, size_t);
 	void DrawFrequencySpectrumStereo(int16_t *, int16_t *, ssize_t, size_t);


### PR DESCRIPTION
I've added another visualizer. This one is a little crazier than the previous ones. It's based off the [lorenz attractor](http://en.wikipedia.org/wiki/Lorenz_system). Most of the equations were taken from this paper http://www.me.rochester.edu/courses/ME406/webexamp5/loreq.pdf and this site http://paulbourke.net/fractals/lorenz/

The average value of the samples is used as the basis for the 'b' varible in the equation described from paulbourke's site. The calculation to scale the 'b' variable is somewhat odd. 'b' needs to be between about 7 and 64. If it's lower than 7, then the attractor looks really simple and kind of boring, and more than 64 the attractor blows up and becomes very large. So far the best solution I've found is to use a linear fitted curve I got by plugging some values into to wolfram alpha, this seems to work well enough.

The coloring is calculated by using the distance to the nearest equilibria, (one of the attractor points of the lorenz).

I'm also rotating the whole attractor based on the left/right channels. The average of the left and right channels control the speed of rotation along the X-axis and Y-axis respectively. The rotation is done using a simple [rotation matrix](http://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations). One thing to note is that the rotation is not around the (0,0,0) point, but around the center of the lorenz.

![lorenz](http://i.imgur.com/R5sEkvW.gif)
