### PR TITLE
Return now playing command

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_ARG_ENABLE(outputs, AS_HELP_STRING([--enable-outputs], [Enable outputs screen
 AC_ARG_ENABLE(visualizer, AS_HELP_STRING([--enable-visualizer], [Enable music visualizer screen @<:@default=no@:>@]), [visualizer=$enableval], [visualizer=no])
 AC_ARG_ENABLE(clock, AS_HELP_STRING([--enable-clock], [Enable clock screen @<:@default=no@:>@]), [clock=$enableval], [clock=no])
 AC_ARG_ENABLE(unicode, AS_HELP_STRING([--enable-unicode], [Enable utf8 support @<:@default=yes@:>@]), [unicode=$enableval], [unicode=yes])
+AC_ARG_ENABLE(np, AS_HELP_STRING([--enable-np], [Enable now playing command @<:@default=no@:>@]), [np=$enableval], [np=no])
 AC_ARG_WITH(curl, AS_HELP_STRING([--with-curl], [Enable fetching lyrics from the Internet @<:@default=auto@:>@]), [curl=$withval], [curl=auto])
 AC_ARG_WITH(fftw, AS_HELP_STRING([--with-fftw], [Enable fftw support (required for frequency spectrum vizualization) @<:@default=auto@:>@]), [fftw=$withval], [fftw=auto])
 AC_ARG_WITH(pdcurses, AS_HELP_STRING([--with-pdcurses[=LIBNAME]], [Link against pdcurses instead of ncurses @<:@default=XCurses@:>@]), [pdcurses=$withval], [pdcurses=no])
@@ -24,6 +25,10 @@ fi
 
 if test "$clock" = "yes"; then
 	AC_DEFINE([ENABLE_CLOCK], [1], [enables clock screen])
+fi
+
+if test "$np" = "yes"; then
+	AC_DEFINE([ENABLE_NP], [1], [enables now playing command])
 fi
 
 dnl ================================

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -57,6 +57,9 @@ bool configure(int argc, char **argv)
 		("ignore-config-errors", po::value<bool>()->default_value(false), "ignore unknown and invalid options in configuration file")
 		("bindings,b", po::value<std::string>(&bindings_path)->default_value("~/.ncmpcpp/bindings"), "specify bindings file")
 		("screen,s", po::value<std::string>(), "specify initial screen")
+#ifdef ENABLE_NP
+		("now-playing,n", "display currently playing track")
+#endif
 		("help,?", "show help message")
 		("version,v", "display version information")
 	;
@@ -165,6 +168,13 @@ bool configure(int argc, char **argv)
 		if (!vm["port"].defaulted())
 			Mpd.SetPort(vm["port"].as<int>());
 		Mpd.SetTimeout(Config.mpd_connection_timeout);
+
+#ifdef ENABLE_NP
+		if (vm.count("now-playing"))
+		{
+			Config.is_np = true;
+		}
+#endif
 
 		// custom startup screen
 		if (vm.count("screen"))

--- a/src/settings.h
+++ b/src/settings.h
@@ -162,6 +162,9 @@ struct Configuration
 	bool ask_for_locked_screen_width_part;
 	bool allow_for_physical_item_deletion;
 	bool progressbar_boldness;
+#ifdef ENABLE_NP
+	bool is_np;
+#endif
 	
 	unsigned mpd_connection_timeout;
 	unsigned crossfade_time;


### PR DESCRIPTION
Hi,

we discussed this about a week ago in PM, and finally I got some time yesterday to code.

I find such functionality quite essential for every audio player (modular or not, mpd-oriented or not), since it is the only way external applications can get song information from the player inside an operating system. Some write files (like Audacious, Sonata), others (deadbeef) -- provide switches to display information for a currently playing track. It is useful in cases when you want to use such information in IM (like an IRC/Jabber client), and some people even mentioned it on boards. Of course for super-scripting cases (for example on a server) I would use mpc and its powerful commandline, but for a desktop I do not need 2 players for such simple tasks, really.

This one adds configure switches to enable/disable the feature and reuses some code block from the main loop in ncmpcpp.cpp. It displays currently playing song according to song_status_format value defined in the config.

Note, it is just the 1st draft, so comments and corrections are welcome.

At the moment, as you may have noticed, it's for 0.6.x branch (which, by the way has default config stating '--now-playing' switch while it doesn't exist), because master has too many compilation errors with GCC 4.6. I'll work on it once I switch my boxes to 4.9 or even 5.1 (I suppose 0.7 will be released by that time).

Thanks!