### PR TITLE
Compilation fixes for macosx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,9 @@ PKG_CHECK_MODULES([ICU], [icu-uc], [
 		CPPFLAGS="$old_CPPFLAGS"
 		LIBS="$old_LIBS",
 	)
-],)
+],
+  []
+)
 
 dnl =============================
 dnl = checking for boost.thread =

--- a/src/utility/wide_string.cpp
+++ b/src/utility/wide_string.cpp
@@ -18,6 +18,7 @@
  *   51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.              *
  ***************************************************************************/
 
+#include <string>
 #include <boost/locale/encoding_utf.hpp>
 #include <cassert>
 #include "utility/wide_string.h"


### PR DESCRIPTION
1. Added empty action-if-not-found to PKG_CHECK_MODULES on icu check. 
I added it because configuration fails if pkg-config doesn't know about icu library. It happens regardless of boost configuration (with icu or without)
2. Small fix to avoid clang error "implicit instantiation of undefined template"