### PR TITLE
Fix doc/config multiplier typo

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -74,7 +74,7 @@
 ## Multiply received samples by given value. Very
 ## useful for proper visualization of quiet music.
 ##
-#visualizer_sample_multipler = 1
+#visualizer_sample_multiplier = 1
 #
 ##
 ## Note: Below parameter defines how often ncmpcpp


### PR DESCRIPTION
Fixes multiplier typo in the sample config file