### PR TITLE
Fixed lyricwiki.com api url redirect bug

### DIFF
--- a/compile
+++ b/compile
@@ -1,1 +1,0 @@
-/usr/share/automake-1.14/compile

--- a/compile
+++ b/compile
@@ -1,0 +1,1 @@
+/usr/share/automake-1.14/compile

--- a/src/curl_handle.cpp
+++ b/src/curl_handle.cpp
@@ -35,7 +35,7 @@ namespace
 	}
 }
 
-CURLcode Curl::perform(std::string &data, const std::string &URL, const std::string &referer, unsigned timeout)
+CURLcode Curl::perform(std::string &data, const std::string &URL, const std::string &referer, unsigned timeout, bool follow_redirect)
 {
 	CURLcode result;
 	CURL *c = curl_easy_init();
@@ -45,7 +45,8 @@ CURLcode Curl::perform(std::string &data, const std::string &URL, const std::str
 	curl_easy_setopt(c, CURLOPT_CONNECTTIMEOUT, timeout);
 	curl_easy_setopt(c, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(c, CURLOPT_USERAGENT, "ncmpcpp " VERSION);
-	curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+	if (follow_redirect)
+	  curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
 	if (!referer.empty())
 		curl_easy_setopt(c, CURLOPT_REFERER, referer.c_str());
 	result = curl_easy_perform(c);

--- a/src/curl_handle.cpp
+++ b/src/curl_handle.cpp
@@ -45,6 +45,7 @@ CURLcode Curl::perform(std::string &data, const std::string &URL, const std::str
 	curl_easy_setopt(c, CURLOPT_CONNECTTIMEOUT, timeout);
 	curl_easy_setopt(c, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(c, CURLOPT_USERAGENT, "ncmpcpp " VERSION);
+	curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
 	if (!referer.empty())
 		curl_easy_setopt(c, CURLOPT_REFERER, referer.c_str());
 	result = curl_easy_perform(c);

--- a/src/curl_handle.cpp
+++ b/src/curl_handle.cpp
@@ -46,7 +46,7 @@ CURLcode Curl::perform(std::string &data, const std::string &URL, const std::str
 	curl_easy_setopt(c, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(c, CURLOPT_USERAGENT, "ncmpcpp " VERSION);
 	if (follow_redirect)
-	  curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+		curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
 	if (!referer.empty())
 		curl_easy_setopt(c, CURLOPT_REFERER, referer.c_str());
 	result = curl_easy_perform(c);

--- a/src/curl_handle.h
+++ b/src/curl_handle.h
@@ -30,7 +30,7 @@
 
 namespace Curl
 {
-  CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10, bool follow_redirect = false);
+	CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10, bool follow_redirect = false);
 	
 	std::string escape(const std::string &s);
 }

--- a/src/curl_handle.h
+++ b/src/curl_handle.h
@@ -30,7 +30,7 @@
 
 namespace Curl
 {
-	CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10);
+  CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10, bool follow_redirect = false);
 	
 	std::string escape(const std::string &s);
 }

--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -118,7 +118,7 @@ LyricsFetcher::Result LyricwikiFetcher::fetch(const std::string &artist, const s
 		result.first = false;
 		
 		std::string data;
-		CURLcode code = Curl::perform(data, result.second);
+		CURLcode code = Curl::perform(data, result.second, "", 10, true);
 		
 		if (code != CURLE_OK)
 		{
@@ -193,7 +193,7 @@ LyricsFetcher::Result GoogleLyricsFetcher::fetch(const std::string &artist, cons
 		result.second = curl_easy_strerror(code);
 		return result;
 	}
-	
+
 	auto urls = getContent("<A HREF=\"(.*?)\">here</A>", data);
 	
 	if (urls.empty() || !isURLOk(urls[0]))

--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -193,7 +193,7 @@ LyricsFetcher::Result GoogleLyricsFetcher::fetch(const std::string &artist, cons
 		result.second = curl_easy_strerror(code);
 		return result;
 	}
-
+	
 	auto urls = getContent("<A HREF=\"(.*?)\">here</A>", data);
 	
 	if (urls.empty() || !isURLOk(urls[0]))


### PR DESCRIPTION
Due to a (presumably) recent change in the URL format of lyrics.wikia.com, the url that is returned after a successful search hits a 301 redirect to the new url style and does not work with ncmpcpp as it stands.

Old url style : http://lyrics.wikia.com/Sonata_Arctica:Land_Of_The_Free
New url style: http://lyrics.wikia.com/wiki/Sonata_Arctica:Land_Of_The_Free

This pull req simply tells curl to properly follow redirects when called.