### PR TITLE
Fixed lyricwiki.com redirect issue, with curl followlocation optional

### DIFF
--- a/src/curl_handle.cpp
+++ b/src/curl_handle.cpp
@@ -35,7 +35,7 @@ namespace
 	}
 }
 
-CURLcode Curl::perform(std::string &data, const std::string &URL, const std::string &referer, unsigned timeout)
+CURLcode Curl::perform(std::string &data, const std::string &URL, const std::string &referer, unsigned timeout, bool follow_redirect)
 {
 	CURLcode result;
 	CURL *c = curl_easy_init();
@@ -45,6 +45,8 @@ CURLcode Curl::perform(std::string &data, const std::string &URL, const std::str
 	curl_easy_setopt(c, CURLOPT_CONNECTTIMEOUT, timeout);
 	curl_easy_setopt(c, CURLOPT_NOSIGNAL, 1);
 	curl_easy_setopt(c, CURLOPT_USERAGENT, "ncmpcpp " VERSION);
+	if (follow_redirect)
+		curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
 	if (!referer.empty())
 		curl_easy_setopt(c, CURLOPT_REFERER, referer.c_str());
 	result = curl_easy_perform(c);

--- a/src/curl_handle.h
+++ b/src/curl_handle.h
@@ -30,7 +30,7 @@
 
 namespace Curl
 {
-	CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10);
+	CURLcode perform(std::string &data, const std::string &URL, const std::string &referer = "", unsigned timeout = 10, bool follow_redirect = false);
 	
 	std::string escape(const std::string &s);
 }

--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -118,7 +118,7 @@ LyricsFetcher::Result LyricwikiFetcher::fetch(const std::string &artist, const s
 		result.first = false;
 		
 		std::string data;
-		CURLcode code = Curl::perform(data, result.second);
+		CURLcode code = Curl::perform(data, result.second, "", 10, true);
 		
 		if (code != CURLE_OK)
 		{


### PR DESCRIPTION
Made a new pull req to merge multiple commits.

Same issue as #63.

CURLOPT_FOLLOWLOCATION is only turned on for LyricwikiFetcher.
This now works with both GoogleLyricsFetcher and LyricwikiFetcher.