### PR TITLE
use "" for root of music not "/"

### DIFF
--- a/src/browser.cpp
+++ b/src/browser.cpp
@@ -131,7 +131,7 @@ Browser::Browser()
 : m_update_request(true)
 , m_local_browser(false)
 , m_scroll_beginning(0)
-, m_current_directory("/")
+, m_current_directory("")
 {
 	w = NC::Menu<MPD::Item>(0, MainStartY, COLS, MainHeight, Config.browser_display_mode == DisplayMode::Columns && Config.titles_visibility ? Display::Columns(COLS) : "", Config.main_color, NC::Border());
 	w.setHighlightColor(Config.main_highlight_color);
@@ -439,9 +439,6 @@ void Browser::getDirectory(std::string directory)
 		directory.resize(directory.length()-3);
 		directory = getParentDirectory(directory);
 	}
-	// when we go down to root, it can be empty
-	if (directory.empty())
-		directory = "/";
 
 	std::vector<MPD::Item> items;
 	if (m_local_browser)

--- a/src/tag_editor.cpp
+++ b/src/tag_editor.cpp
@@ -141,7 +141,7 @@ std::vector<MPD::Song> TagsWindow::getSelectedSongs()
 
 /**********************************************************************/
 
-TagEditor::TagEditor() : FParser(0), FParserHelper(0), FParserLegend(0), FParserPreview(0), itsBrowsedDir("/")
+TagEditor::TagEditor() : FParser(0), FParserHelper(0), FParserLegend(0), FParserPreview(0), itsBrowsedDir("")
 {
 	PatternsFile = Config.ncmpcpp_directory + "patterns.list";
 	SetDimensions(0, COLS);
@@ -291,10 +291,10 @@ void TagEditor::update()
 		Dirs->Window::clear();
 		Tags->clear();
 		
-		if (itsBrowsedDir != "/")
+		if (itsBrowsedDir != "")
 			Dirs->addItem(std::make_pair("..", getParentDirectory(itsBrowsedDir)));
 		else
-			Dirs->addItem(std::make_pair(".", "/"));
+			Dirs->addItem(std::make_pair(".", ""));
 		MPD::DirectoryIterator directory = Mpd.GetDirectories(itsBrowsedDir), end;
 		for (; directory != end; ++directory)
 		{
@@ -941,13 +941,11 @@ void TagEditor::LocateSong(const MPD::Song &s)
 		if (last_slash != std::string::npos)
 			itsBrowsedDir = itsBrowsedDir.substr(0, last_slash);
 		else
-			itsBrowsedDir = "/";
-		if (itsBrowsedDir.empty())
-			itsBrowsedDir = "/";
+			itsBrowsedDir = "";
 		Dirs->clear();
 		update();
 	}
-	if (itsBrowsedDir == "/")
+	if (itsBrowsedDir.empty())
 		Dirs->reset(); // go to the first pos, which is "." (music dir root)
 	
 	// highlight directory we need and get files from it


### PR DESCRIPTION
When using commands like lsinfo, "" refers to the root of the music directory, not "/".  This behavior changed recently in mpd-git.  ncmpcpp would do something like the following:

    lsinfo "ARTIST/ALBUM"
    user hits [..]
    lsinfo "ARTIST"
    user hits [..]
    lsinfo "/" <= PATCH fixes this

I have tested the browser portion of this patch but have only verified that the tag editor no longer locks up due to my not really using tag editor in my setup.