### PR TITLE
Update the compilation steps in the INSTALL guide

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -19,17 +19,16 @@ diffs or instructions to the address given in the `README' so they can
 be considered for the next release.  If at some point `config.cache'
 contains results you don't want to keep, you may remove or edit it.
 
-   The file `configure.ac' is used to create `configure' by a program
-called `autoconf'.  You only need `configure.ac' if you want to change
-it or regenerate `configure' using a newer version of `autoconf'.
+   The file `configure.ac' is used to generate `configure' by a program
+called `autogen'.  You only need `configure.ac' if you want to change
+it or regenerate `configure' using a newer version of `autogen'.
 
 The simplest way to compile this package is:
 
   1. `cd' to the directory containing the package's source code and type
-     `./configure' to configure the package for your system.  If you're
-     using `csh' on an old version of System V, you might need to type
-     `sh ./configure' instead to prevent `csh' from trying to execute
-     `configure' itself.
+     `./autogen.sh' to generate the `./configure' file.
+     Then `./configure' while automaticly be executed to configure the
+     package for your system.
 
      Running `configure' takes a while.  While running, it prints some
      messages telling which features it is checking for.


### PR DESCRIPTION
This should avoid confusion as in the issue #86

Changes in the INSTALL guide :
- Replace 'autoconf' by 'autogen'.
- Replace step 1, previously run './configure', by run './autogen'.
- Running 'configure' is not necessary since 'autogen' run it.