### PR TITLE
Add 'execute_on_player_change' option

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -286,6 +286,14 @@
 ##
 #execute_on_song_change = ""
 #
+##
+## Note: Custom command that will be executed each
+## time player changes (e.g. play/pause events). 
+## Useful for notifications etc.
+##
+#
+#execute_on_player_change = ""
+#
 #playlist_show_mpd_host = no
 #
 #playlist_show_remaining_time = no

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -375,6 +375,9 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("execute_on_song_change", assign_default(
 		execute_on_song_change, ""
 	));
+	p.add("execute_on_player_change", assign_default(
+		execute_on_player_change, ""
+	));
 	p.add("playlist_show_mpd_host", yes_no(
 		playlist_show_mpd_host, false
 	));

--- a/src/settings.h
+++ b/src/settings.h
@@ -76,6 +76,7 @@ struct Configuration
 	std::string external_editor;
 	std::string system_encoding;
 	std::string execute_on_song_change;
+        std::string execute_on_player_change;
 	std::string lastfm_preferred_language;
 	std::wstring progressbar;
 	std::wstring visualizer_chars;

--- a/src/settings.h
+++ b/src/settings.h
@@ -76,7 +76,7 @@ struct Configuration
 	std::string external_editor;
 	std::string system_encoding;
 	std::string execute_on_song_change;
-        std::string execute_on_player_change;
+	std::string execute_on_player_change;
 	std::string lastfm_preferred_language;
 	std::wstring progressbar;
 	std::wstring visualizer_chars;
@@ -200,4 +200,3 @@ struct Configuration
 extern Configuration Config;
 
 #endif // NCMPCPP_SETTINGS_H
-

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -473,6 +473,10 @@ void Status::Changes::database()
 
 void Status::Changes::playerState()
 {
+    GNUC_UNUSED int res;
+    if (!Config.execute_on_player_change.empty())
+        res = system(Config.execute_on_player_change.c_str());
+
 	switch (m_player_state)
 	{
 		case MPD::psPlay:

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -246,7 +246,7 @@ void Status::update(int event)
 	m_playlist_length = st.playlistLength();
 	m_total_time = st.totalTime();
 	m_volume = st.volume();
-	
+
 	if (event & MPD_IDLE_DATABASE)
 		Changes::database();
 	if (event & MPD_IDLE_STORED_PLAYLIST)
@@ -432,10 +432,10 @@ void Status::Changes::playlist(unsigned previous_version)
 		else // otherwise just add it to playlist
 			myPlaylist->main().addItem(std::move(*s));
 	}
-	
+
 	myPlaylist->reloadTotalLength();
 	myPlaylist->reloadRemaining();
-	
+
 	if (isVisible(myBrowser))
 		markSongsInPlaylist(myBrowser->main());
 	if (isVisible(mySearcher))
@@ -473,9 +473,9 @@ void Status::Changes::database()
 
 void Status::Changes::playerState()
 {
-    GNUC_UNUSED int res;
-    if (!Config.execute_on_player_change.empty())
-        res = system(Config.execute_on_player_change.c_str());
+	GNUC_UNUSED int res;
+	if (!Config.execute_on_player_change.empty())
+		res = system(Config.execute_on_player_change.c_str());
 
 	switch (m_player_state)
 	{
@@ -507,7 +507,7 @@ void Status::Changes::playerState()
 		default:
 			break;
 	}
-	
+
 	std::string state = playerStateToString(m_player_state);
 	if (Config.design == Design::Alternative)
 	{
@@ -522,7 +522,7 @@ void Status::Changes::playerState()
 		else
 			*wFooter << NC::Format::Bold << state << NC::Format::NoBold;
 	}
-	
+
 	// needed for immediate display after starting
 	// player from stopped state or seeking
 	elapsedTime(false);
@@ -684,7 +684,7 @@ void Status::Changes::flags()
 {
 	if (!Config.header_visibility && Config.design == Design::Classic)
 		return;
-	
+
 	std::string switch_state;
 	switch (Config.design)
 	{
@@ -743,7 +743,7 @@ void Status::Changes::mixer()
 {
 	if (!Config.display_volume_level || (!Config.header_visibility && Config.design == Design::Classic))
 		return;
-	
+
 	switch (Config.design)
 	{
 		case Design::Classic:


### PR DESCRIPTION
This adds a config file option to allow executing a command whenever the _player_ updates, not just the song ID. Useful for when someone needs something to happen (a script to run) not only whenever a new song starts playing, but also when the player pauses and starts playing again as well.

I had a current-song script that needed updating whenever ncmpcpp paused or started playing again to change an icon from a '>' to a '||'. The 'execute_on_song_change' option worked for the name of the song playing but not for whether it was paused or playing.