### PR TITLE
Make `autogen.sh` not run `configure` so consistent with `INSTALL`

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,21 +25,23 @@ it or regenerate `configure' using a newer version of `autoconf'.
 
 The simplest way to compile this package is:
 
-  1. `cd' to the directory containing the package's source code and type
-     `./configure' to configure the package for your system.  If you're
-     using `csh' on an old version of System V, you might need to type
-     `sh ./configure' instead to prevent `csh' from trying to execute
-     `configure' itself.
+  1. `cd' to the directory containing the package's source code.
 
-     Running `configure' takes a while.  While running, it prints some
-     messages telling which features it is checking for.
+  For the next two commands, `csh' users will need to prefix them with
+  `sh '.
 
-  2. Type `make' to compile the package.
+  2. Run `./autogen.sh' to generate the `configure' script.
 
-  3. Type `make install' to install the programs and any data files and
-     documentation.
+  3. Run `./configure' to configure the package for your system.  This
+     will take a while.  While running, it prints some messages
+     telling which features it is checking for.
 
-  4. You can remove the program binaries and object files from the
+  4. Run `make' to compile the package.
+
+  5. Type `make install' to install the programs and any data files
+     and documentation.
+
+  6. You can remove the program binaries and object files from the
      source code directory by typing `make clean'.  
 
 Compilers and Options

--- a/autogen.sh
+++ b/autogen.sh
@@ -156,8 +156,3 @@ $AUTOMAKE --add-missing $AUTOMAKE_FLAGS || exit 1
 
 echo "  $AUTOCONF"
 $AUTOCONF || exit 1
-
-cd "$olddir"
-if test x$NOCONFIGURE = x; then
-	"$srcdir"/configure "$@" || exit 1
-fi


### PR DESCRIPTION
Also changed `INSTALL` to have easier and updated installation instructions.
