### PR TITLE
Change random shuffle to use mt19937 generator explicitly

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -37,5 +37,6 @@ bool SeekingInProgress = false;
 
 std::string VolumeState;
 boost::posix_time::ptime Timer;
+std::mt19937 rng;
 
 }

--- a/src/global.h
+++ b/src/global.h
@@ -22,6 +22,7 @@
 #define NCMPCPP_GLOBAL_H
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <random>
 #include "mpdpp.h"
 #include "screen.h"
 
@@ -57,6 +58,9 @@ extern std::string VolumeState;
 
 // global timer
 extern boost::posix_time::ptime Timer;
+
+// global random number generator
+extern std::mt19937 rng;
 
 }
 

--- a/src/mpdpp.cpp
+++ b/src/mpdpp.cpp
@@ -24,6 +24,7 @@
 #include <map>
 
 #include "charset.h"
+#include "global.h"
 #include "mpdpp.h"
 
 MPD::Connection Mpd;
@@ -570,7 +571,7 @@ bool Connection::AddRandomTag(mpd_tag_type tag, size_t number)
 	if (number > tags.size())
 		return false;
 
-	std::random_shuffle(tags.begin(), tags.end());
+	std::shuffle(tags.begin(), tags.end(), Global::rng);
 	auto it = tags.begin();
 	for (size_t i = 0; i < number && it != tags.end(); ++i)
 	{
@@ -609,7 +610,7 @@ bool Connection::AddRandomSongs(size_t number)
 	}
 	else
 	{
-		std::random_shuffle(files.begin(), files.end());
+		std::shuffle(files.begin(), files.end(), Global::rng);
 		StartCommandsList();
 		auto it = files.begin();
 		for (size_t i = 0; i < number && it != files.end(); ++i, ++it)

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -88,6 +88,7 @@ int main(int argc, char **argv)
 	
 	using Global::VolumeState;
 	using Global::Timer;
+	using Global::rng;
 	
 	srand(time(nullptr));
 	std::setlocale(LC_ALL, "");
@@ -131,6 +132,9 @@ int main(int argc, char **argv)
 	
 	// initialize global timer
 	Timer = boost::posix_time::microsec_clock::local_time();
+
+	// initialize global random number generator
+	rng.seed(std::time(nullptr));
 	
 	// initialize playlist
 	myPlaylist->switchTo();


### PR DESCRIPTION
Current implementation of add random items to playlist uses `std::random_shuffle(b, e)` to randomize the items before adding the first *n* items to the playlist. The problem with this solution is that `std::random_shuffle(b, e)` derives its randomness from whatever the implementation has decided on, meaning it can actually not give a toss about the RNG seed that is initialized at the start of execution, resulting in same random items being added every execution of the program.

This change switches `std::random_shuffle(b, e)` to `std::shuffle(b, e, g)`, which accepts a random number engine as the third argument. The random number engine used in this implementation is MT19937, which is defined as global and seeded with system time at the beginning of execution. This should be a much more portable solution to shuffling the array, as there is no doubt where the randomness for the shuffle arrives from.

This change fixes #120 which seems to be prevailing on OS X, which is what I use as my operating system as well.