### PR TITLE
fix 32 bit platforms

### DIFF
--- a/src/utility/html.cpp
+++ b/src/utility/html.cpp
@@ -66,7 +66,7 @@ void stripHtmlTags(std::string &s)
 	for (size_t i = s.find("<"); i != std::string::npos; i = s.find("<"))
 	{
 		size_t j = s.find(">", i)+1;
-		if (s.compare(i, std::min(3ul, j-i), "<p ") == 0 || s.compare(i, j-i, "</p>") == 0)
+		if (s.compare(i, std::min(3ul, (unsigned long)j-i), "<p ") == 0 || s.compare(i, j-i, "</p>") == 0)
 			s.replace(i, j-i, "\n");
 		else
 			s.replace(i, j-i, "");


### PR DESCRIPTION
v0.7.6 fails to compile on 32bit platforms such as armv6, armv7, and i686.

The buildlog can be found [here](https://build.voidlinux.eu/builders/armv7l-musl_builder/builds/14874/steps/shell_3/logs/stdio). Be aware that this piece of code might be prone to integer overflows. especially on 64 bit.

This patch fixes the compile time error and is already [shipped with VoidLinux](https://github.com/voidlinux/void-packages/commit/db28113b9ada0e68d40f318292d3f69d8db8198e). Be aware, that it does *not* fix any integer overflows.