### PR TITLE
doc: Add missing .TP to man page

### DIFF
--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -113,6 +113,7 @@ Format for songs' list.
 Song's format for statusbar.
 .TP
 .B song_library_format
+.TP
 .B alternative_header_first_line_format = TEXT
 Now playing song format for the first line in alternative user interface header window.
 .TP


### PR DESCRIPTION
There should probably be an actual description too, but this fixes the
formatting.