### PR TITLE
Store error.log to $XDG_CACHE_HOME by default

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -16,6 +16,13 @@
 #ncmpcpp_directory = ~/.ncmpcpp
 #
 ##
+## Directory for storing log files (like error.log).
+## It defaults to $XDG_CACHE_HOME/ncmpcpp.
+##
+#
+#logs_directory = ~/.cache/ncmpcpp
+#
+##
 ## Directory for storing downloaded lyrics. It
 ## defaults to ~/.lyrics since other MPD clients
 ## (eg. ncmpc) also use that location.

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -58,6 +58,9 @@ Directory for storing ncmpcpp related files. Changing it is useful if you want t
 .B lyrics_directory = PATH
 Directory for storing downloaded lyrics. It defaults to ~/.lyrics since other MPD clients (eg. ncmpc) also use that location.
 .TP
+.B logs_directory = PATH
+Directory for storing log files (like error.log). It defaults to $XDG_CACHE_HOME/ncmpcpp.
+.TP
 .B mpd_host = HOST
 Connect to MPD running on specified host/unix socket. When HOST starts with a '/', it is assumed to be a unix socket. Note: MPD_HOST environment variable overrides this setting.
 .TP

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -192,6 +192,7 @@ bool configure(int argc, char **argv)
 
 		// create directories
 		boost::filesystem::create_directory(Config.ncmpcpp_directory);
+		boost::filesystem::create_directory(Config.logs_directory);
 		boost::filesystem::create_directory(Config.lyrics_directory);
 
 		// try to get MPD connection details from environment variables

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 	atexit(do_at_exit);
 	
 	// redirect std::cerr output to ~/.ncmpcpp/error.log file
-	errorlog.open((Config.ncmpcpp_directory + "error.log").c_str(), std::ios::app);
+	errorlog.open((Config.logs_directory + "error.log").c_str(), std::ios::app);
 	cerr_buffer = std::cerr.rdbuf();
 	std::cerr.rdbuf(errorlog.rdbuf());
 	

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -177,6 +177,21 @@ NC::Buffer buffer(const std::string &v)
 	return result;
 }
 
+std::string xdg_cache_home()
+{
+	std::string result;
+	const char *env_xdg_cache_home = getenv("XDG_CACHE_HOME");
+	if (env_xdg_cache_home == nullptr)
+		result = "~/.cache/";
+	else
+	{
+		result = env_xdg_cache_home;
+		if (!result.empty() && result.back() != '/')
+			result += "/";
+	}
+	return result;
+}
+
 void deprecated(const char *option, double version_removal, const char *advice)
 {
 	std::cerr << "WARNING: Variable '" << option
@@ -210,6 +225,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 
 	// keep the same order of variables as in configuration file
 	p.add("ncmpcpp_directory", &ncmpcpp_directory, "~/.ncmpcpp/", adjust_directory);
+	p.add("logs_directory", &logs_directory, xdg_cache_home() + "ncmpcpp/", adjust_directory);
 	p.add("lyrics_directory", &lyrics_directory, "~/.lyrics/", adjust_directory);
 	p.add<void>("mpd_host", nullptr, "localhost", [](std::string host) {
 			expand_home(host);

--- a/src/settings.h
+++ b/src/settings.h
@@ -58,6 +58,7 @@ struct Configuration
 	bool read(const std::vector<std::string> &config_paths, bool ignore_errors);
 
 	std::string ncmpcpp_directory;
+	std::string logs_directory;
 	std::string lyrics_directory;
 
 	std::string mpd_music_dir;


### PR DESCRIPTION
This commit adds an option to the ncmpcpp config to specify the location of log files (like `error.log`). By default, ncmpcpp now stores `error.log` into `$XDG_CACHE_HOME/ncmpcpp`.

This should fix #110.