### PR TITLE
Add a README, showing enable visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# NCurses Music Player Client (Plus Plus)
+
+## ncmpcpp – featureful ncurses based MPD client inspired by ncmpc
+
+### Main features:
+
+* tag editor
+* playlist editor
+* easy to use search engine
+* media library
+* music visualizer
+* ability to fetch artist info from last.fm
+* new display mode
+* alternative user interface
+* ability to browse and add files from outside of MPD music directory
+…and a lot more minor functions.
+
+### Dependencies:
+
+* boost library
+* ncurses library
+* readline library
+* curl library (optional, required for fetching lyrics and last.fm data)
+* fftw library (optional, required for frequency spectrum music visualization mode)
+* tag library (optional, required for tag editing)
+
+
+### Known issues:
+* No full support for handling encodings other than UTF-8.
+
+### Installation:
+
+The simplest way to compile this package is:
+
+  1. `cd` to the directory containing the package's source code.
+
+  For the next two commands, `csh` users will need to prefix them with
+  `sh `.
+
+  2. Run `./autogen.sh` to generate the `configure` script.
+
+  3. Run `./configure` to configure the package for your system.  This
+     will take a while.  While running, it prints some messages
+     telling which features it is checking for.
+
+  4. Run `make` to compile the package.
+
+  5. Type `make install` to install the programs and any data files
+     and documentation.
+
+  6. You can remove the program binaries and object files from the
+     source code directory by typing `make clean`.
+
+Detailed intallation instructions can be found in the `INSTALL` file. 
+
+### Optional features:
+
+Optional features can be enable by specifying them during configure. For
+example, to enable visualizer run `./configure --enable-visualizer`. 
+
+Additional details can be found in the INSTALL file. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # NCurses Music Player Client (Plus Plus)
 
+Project page - http://rybczak.net/ncmpcpp/
+
 ## ncmpcpp – featureful ncurses based MPD client inspired by ncmpc
 
 ### Main features:


### PR DESCRIPTION
Even though I used ncmpcpp for a long time, after installing it on a new computer, I struggled for hours trying to find how to enable the visualizer. And also found many users across many forums asking the same. 

I thought it would be helpful if it is right here in the readme. Most of the file's contents are from [here](http://rybczak.net/ncmpcpp/). Added markdown for decoration and specified the example options. 