### PR TITLE
Change automake init macros and includes var per automake warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ncmcpp], [0.8_dev])
+AC_INIT([ncmpcpp], [0.8_dev])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([subdir-objects])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,7 @@
-AC_INIT(configure.ac)
+AC_INIT([ncmcpp], [0.8_dev])
+AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE(ncmpcpp, 0.8_dev)
+AM_INIT_AUTOMAKE([subdir-objects])
 
 m4_include([m4/ax_lib_readline.m4])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ ncmpcpp_SOURCES = \
 	title.cpp
 
 # set the include path found by configure
-INCLUDES= $(all_includes)
+AM_CPPFLAGS= $(all_includes)
 
 # the library search path.
 ncmpcpp_LDFLAGS = $(all_libraries)


### PR DESCRIPTION
Automake was throwing a few warnings when running `autogen.sh`. These changes to `configure.ac` and `src/Makefile.am` fix them. I believe it is due to the versions of automake and autoconf I have.

Versions:
autoconf | autoheader 2.69
automake | aclocal 1.14.1

The `configure.ac` changes follow the [recommendation they link to in the warning](http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation). I  also added the `subdir-objects` option to get `src/` sub directories working.

Warnings:
```
$ ./autogen.sh 
checking for autoconf ... autoconf
checking for autoheader ... autoheader
checking for automake ... automake
checking for aclocal ... aclocal
checking for libtoolize ... libtoolize
Generating configuration files for ncmpcpp, please wait....
  aclocal 
  autoheader
  libtoolize --automake
  automake --add-missing 
configure.ac:3: warning: AM_INIT_AUTOMAKE: two- and three-arguments forms are deprecated.  For more info, see:
configure.ac:3: http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
configure.ac:11: installing './compile'
configure.ac:11: installing './config.guess'
configure.ac:11: installing './config.sub'
configure.ac:3: installing './install-sh'
configure.ac:3: installing './missing'
src/Makefile.am:56: warning: 'INCLUDES' is the old name for 'AM_CPPFLAGS' (or '*_CPPFLAGS')
src/Makefile.am:2: warning: source file 'curses/formatted_color.cpp' is in a subdirectory,
src/Makefile.am:2: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
src/Makefile.am:2: warning: source file 'curses/scrollpad.cpp' is in a subdirectory,
src/Makefile.am:2: but option 'subdir-objects' is disabled
src/Makefile.am:2: warning: source file 'curses/window.cpp' is in a subdirectory,
src/Makefile.am:2: but option 'subdir-objects' is disabled
... (omitted other subdir-objects warnings)
src/Makefile.am:2: warning: source file 'utility/wide_string.cpp' is in a subdirectory,
src/Makefile.am:2: but option 'subdir-objects' is disabled
src/Makefile.am: installing './depcomp'
  autoconf
```

Autogen after changes:
```
$ ./autogen.sh 
checking for autoconf ... autoconf
checking for autoheader ... autoheader
checking for automake ... automake
checking for aclocal ... aclocal
checking for libtoolize ... libtoolize
Generating configuration files for ncmpcpp, please wait....
  aclocal 
  autoheader
  libtoolize --automake
  automake --add-missing 
  autoconf
```

:+1: