### PR TITLE
Fix crash when jumping to playing song in playlist editor & improve detection for songs not in playlists

### DIFF
--- a/src/screens/playlist_editor.cpp
+++ b/src/screens/playlist_editor.cpp
@@ -529,7 +529,7 @@ void PlaylistEditor::locateSong(const MPD::Song &s)
 		for (auto pl_it = current_successor; pl_it != end; ++pl_it)
 			if (locate_and_switch_playlist(pl_it))
 				return;
-		for (auto pl_it = begin; pl_it != current_successor; ++pl_it)
+		for (auto pl_it = begin; pl_it != Playlists.currentV(); ++pl_it)
 			if (locate_and_switch_playlist(pl_it))
 				return;
 	}
@@ -545,19 +545,9 @@ void PlaylistEditor::locateSong(const MPD::Song &s)
 		}
 	}
 
-	// Wrap back to the beginning of current playlist
-	if (Content.size() != 0)
-	{
-		auto song_it = std::find(Content.beginV(), Content.currentV(), s);
-		if (song_it != Content.currentV())
-		{
-			Content.highlight(song_it - Content.beginV());
-			nextColumn();
-			return;
-		}
-	}
-
-	Statusbar::print("Song is not from playlists");
+	// If the currently highlighted song is what we are looking for, don't show error
+	if (Content.currentV() == Content.endV() || *Content.currentV() != s)
+		Statusbar::print("Song is not from playlists");
 }
 
 namespace {

--- a/src/screens/playlist_editor.cpp
+++ b/src/screens/playlist_editor.cpp
@@ -485,7 +485,7 @@ void PlaylistEditor::locatePlaylist(const MPD::Playlist &playlist)
 void PlaylistEditor::gotoSong(size_t playlist_index, size_t song_index)
 {
 	Playlists.highlight(playlist_index);
-	Content.clear();
+	requestContentsUpdate();
 	update();
 	Content.highlight(song_index);
 


### PR DESCRIPTION
Notes for improving the detection:

> Hmm, there is one more glitch - if the cursor is on the last occurrence of the song in playlists, then if you try to jump to the next occurrence it will show a message "Song is not from playlists".

It seems that the code to fix this problem is a duplicate, see line [534] and line 546. The only difference is checking whether `Content` is empty: one version wrote `!Content.empty()`, and the other version wrote `Content.size() != 0`.

Why does the fix seem to work? Because the second  loop that iterates through the beginning part of the playlists was modified to take the current playlist into account. This is inefficient -- if the currently highlighted playlist doesn't contain what we're looking for, the songs in the rear part of the playlist are scanned twice.

My solution is based on my original version, which scans all songs except the currently highlighted song. Here's the trick: if any other song doesn't match, no action will be taken to alter the playlist or the content. Now it's time to check the only song not scanned yet -- the currently highlighted song.

[534]: https://github.com/arybczak/ncmpcpp/commit/0cdbe31ecbbf7a133c41e0f44fba1d06c8a8faa1#diff-dbc448e6fd0301f41956835f6f1ee5e9R534