### PR TITLE
Add command-line switch '--quiet' to suppress extra output

### DIFF
--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -33,6 +33,9 @@ Specify the startup screen (<name> may be: help, playlist, browser, search_engin
 .B \-S, \-\-slave-screen <name>
 Specify the startup slave screen (<name> may be: help, playlist, browser, search_engine, media_library, playlist_editor, tag_editor, outputs, visualizer, clock)
 .TP
+.B \-q, \-\-quiet
+Suppress logs and excess output
+.TP
 .B \-?, \-\-help
 Display help.
 .TP

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -24,6 +24,7 @@
 #include <boost/program_options.hpp>
 #include <iomanip>
 #include <iostream>
+#include <fstream>
 
 #include "bindings.h"
 #include "configuration.h"
@@ -72,6 +73,7 @@ bool configure(int argc, char **argv)
 		xdg_config_home() + "ncmpcpp/config"
 	};
 
+	std::ofstream null_stream;
 	std::string bindings_path;
 	std::vector<std::string> config_paths;
 
@@ -88,12 +90,20 @@ bool configure(int argc, char **argv)
 		("slave-screen,S", po::value<std::string>()->value_name("SCREEN"), "specify the startup slave screen")
 		("help,?", "show help message")
 		("version,v", "display version information")
+		("quiet,q", "suppress logs and excess output")
 	;
 
 	po::variables_map vm;
 	try
 	{
 		po::store(po::parse_command_line(argc, argv, options), vm);
+
+		// suppress messages from std::clog
+		if (vm.count("quiet"))
+		{
+			null_stream.open("/dev/null");
+			std::clog.rdbuf(null_stream.rdbuf());
+		}
 
 		if (vm.count("help"))
 		{

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -73,7 +73,6 @@ bool configure(int argc, char **argv)
 		xdg_config_home() + "ncmpcpp/config"
 	};
 
-	std::ofstream null_stream;
 	std::string bindings_path;
 	std::vector<std::string> config_paths;
 
@@ -101,6 +100,7 @@ bool configure(int argc, char **argv)
 		// suppress messages from std::clog
 		if (vm.count("quiet"))
 		{
+			std::ofstream null_stream;
 			null_stream.open("/dev/null");
 			std::clog.rdbuf(null_stream.rdbuf());
 		}

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -54,6 +54,7 @@ namespace {
 
 std::ofstream errorlog;
 std::streambuf *cerr_buffer;
+std::streambuf *clog_buffer = std::clog.rdbuf();
 
 volatile bool run_resize_screen = false;
 	
@@ -69,8 +70,9 @@ void sighandler(int sig)
 
 void do_at_exit()
 {
-	// restore old cerr buffer
+	// restore old cerr & clog buffers
 	std::cerr.rdbuf(cerr_buffer);
+	std::clog.rdbuf(clog_buffer);
 	errorlog.close();
 	Mpd.Disconnect();
 	NC::destroyScreen();
@@ -91,7 +93,6 @@ int main(int argc, char **argv)
 	
 	std::setlocale(LC_ALL, "");
 	std::locale::global(Charset::internalLocale());
-	std::streambuf *backup = std::clog.rdbuf();
 
 	if (!configure(argc, argv))
 		return 0;
@@ -247,6 +248,5 @@ int main(int argc, char **argv)
 			Statusbar::printf("Unexpected error: %1%", e.what());
 		}
 	}
-	std::clog.rdbuf(backup);
 	return 0;
 }

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -91,6 +91,7 @@ int main(int argc, char **argv)
 	
 	std::setlocale(LC_ALL, "");
 	std::locale::global(Charset::internalLocale());
+	std::streambuf *backup = std::clog.rdbuf();
 
 	if (!configure(argc, argv))
 		return 0;
@@ -246,5 +247,6 @@ int main(int argc, char **argv)
 			Statusbar::printf("Unexpected error: %1%", e.what());
 		}
 	}
+	std::clog.rdbuf(backup);
 	return 0;
 }


### PR DESCRIPTION
If ncmpcpp is started with '-q' or '--quiet', std::clog is redirected to /dev/null, removing a few superfluous messages and logs. Fixes issue #171.