### PR TITLE
Search lyrics by google in specific site

### DIFF
--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -207,11 +207,12 @@ LyricsFetcher::Result GoogleLyricsFetcher::fetch(const std::string &artist,
 	Result result;
 	result.first = false;
 	
-	std::string search_str = Curl::escape(artist);
+	std::string search_str = "site:";
+	search_str += Curl::escape(siteKeyword());
+	search_str += "+";
+	search_str += Curl::escape(artist);
 	search_str += "+";
 	search_str += Curl::escape(title);
-	search_str += "+%2B";
-	search_str += Curl::escape(siteKeyword());
 	
 	std::string google_url = "http://www.google.com/search?hl=en&ie=UTF-8&oe=UTF-8&q=";
 	google_url += search_str;


### PR DESCRIPTION
Follow this [link](https://blog.hubspot.com/marketing/how-to-do-a-google-site-search#sm.001dgce5x4fyeyk10ca17zdpni7oj), I change the `search_str` in `GoogleLyricsFetcher::fetch` with prefix as `site: %siteName%`.
That will give us the better search result