### PR TITLE
Add config option to change error.log location (+ optionally better XDG support)

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -14,6 +14,12 @@
 #ncmpcpp_directory = ~/.ncmpcpp
 #
 ##
+## Directory for storing log files (like error.log).
+##
+#
+#log_directory = ~/.ncmpcpp
+#
+##
 ## Directory for storing downloaded lyrics. It defaults to ~/.lyrics since other
 ## MPD clients (eg. ncmpc) also use that location.
 ##

--- a/doc/config
+++ b/doc/config
@@ -14,10 +14,11 @@
 #ncmpcpp_directory = ~/.ncmpcpp
 #
 ##
-## Directory for storing log files (like error.log).
+## Directory for storing log files (like error.log). It defaults to
+## $XDG_DATA_HOME/ncmpcpp.
 ##
 #
-#log_directory = ~/.ncmpcpp
+#log_directory = ~/.local/share/ncmpcpp
 #
 ##
 ## Directory for storing downloaded lyrics. It defaults to ~/.lyrics since other

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -61,7 +61,7 @@ Supported configuration options:
 Directory for storing ncmpcpp related files. Changing it is useful if you want to store everything somewhere else and provide command line setting for alternative location to config file which defines that while launching ncmpcpp.
 .TP
 .B log_directory = PATH
-Directory for storing log files (like error.log).
+Directory for storing log files (like error.log). It defaults to $XDG_DATA_HOME/ncmpcpp.
 .TP
 .B lyrics_directory = PATH
 Directory for storing downloaded lyrics. It defaults to ~/.lyrics since other MPD clients (eg. ncmpc) also use that location.

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -60,6 +60,9 @@ Supported configuration options:
 .B ncmpcpp_directory = PATH
 Directory for storing ncmpcpp related files. Changing it is useful if you want to store everything somewhere else and provide command line setting for alternative location to config file which defines that while launching ncmpcpp.
 .TP
+.B log_directory = PATH
+Directory for storing log files (like error.log).
+.TP
 .B lyrics_directory = PATH
 Directory for storing downloaded lyrics. It defaults to ~/.lyrics since other MPD clients (eg. ncmpc) also use that location.
 .TP

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -29,6 +29,7 @@
 #include "bindings.h"
 #include "configuration.h"
 #include "config.h"
+#include "helpers.h"
 #include "mpdpp.h"
 #include "format_impl.h"
 #include "settings.h"
@@ -45,17 +46,7 @@ const char *env_home;
 
 std::string xdg_config_home()
 {
-	std::string result;
-	const char *env_xdg_config_home = getenv("XDG_CONFIG_HOME");
-	if (env_xdg_config_home == nullptr)
-		result = "~/.config/";
-	else
-	{
-		result = env_xdg_config_home;
-		if (!result.empty() && result.back() != '/')
-			result += "/";
-	}
-	return result;
+	return getEnvironment("XDG_CONFIG_HOME", "~/.config") + "/";
 }
 
 }

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -199,6 +199,7 @@ bool configure(int argc, char **argv)
 
 		// create directories
 		boost::filesystem::create_directory(Config.ncmpcpp_directory);
+		boost::filesystem::create_directory(Config.log_directory);
 		boost::filesystem::create_directory(Config.lyrics_directory);
 
 		// try to get MPD connection details from environment variables

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -218,3 +218,12 @@ void writeCyclicBuffer(const NC::WBuffer &buf, NC::Window &w, size_t &start_pos,
 	else
 		w << buf;
 }
+
+std::string getEnvironment(const std::string &name, const std::string &fallback)
+{
+	std::string result = fallback;
+	const char *env = getenv(name.c_str());
+	if (env != nullptr)
+		result = env;
+	return result;
+}

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -541,5 +541,7 @@ std::string Timestamp(time_t t);
 std::wstring Scroller(const std::wstring &str, size_t &pos, size_t width);
 void writeCyclicBuffer(const NC::WBuffer &buf, NC::Window &w, size_t &start_pos,
                        size_t width, const std::wstring &separator);
+std::string getEnvironment(const std::string &name,
+                           const std::string &fallback);
 
 #endif // NCMPCPP_HELPERS_H

--- a/src/ncmpcpp.cpp
+++ b/src/ncmpcpp.cpp
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 	atexit(do_at_exit);
 	
 	// redirect std::cerr output to ~/.ncmpcpp/error.log file
-	errorlog.open((Config.ncmpcpp_directory + "error.log").c_str(), std::ios::app);
+	errorlog.open((Config.log_directory + "error.log").c_str(), std::ios::app);
 	cerr_buffer = std::cerr.rdbuf();
 	std::cerr.rdbuf(errorlog.rdbuf());
 	

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -264,6 +264,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 
 	// keep the same order of variables as in configuration file
 	p.add("ncmpcpp_directory", &ncmpcpp_directory, "~/.ncmpcpp/", adjust_directory);
+	p.add("log_directory", &log_directory, "~/.ncmpcpp/", adjust_directory);
 	p.add("lyrics_directory", &lyrics_directory, "~/.lyrics/", adjust_directory);
 	p.add<void>("mpd_host", nullptr, "localhost", [](std::string host) {
 			expand_home(host);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -41,6 +41,11 @@ Configuration Config;
 
 namespace {
 
+std::string xdg_data_home()
+{
+	return getEnvironment("XDG_DATA_HOME", "~/.local/share") + "/";
+}
+
 std::vector<Column> generate_columns(const std::string &format)
 {
 	std::vector<Column> result;
@@ -264,7 +269,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 
 	// keep the same order of variables as in configuration file
 	p.add("ncmpcpp_directory", &ncmpcpp_directory, "~/.ncmpcpp/", adjust_directory);
-	p.add("log_directory", &log_directory, "~/.ncmpcpp/", adjust_directory);
+	p.add("log_directory", &log_directory, xdg_data_home() + "ncmpcpp/", adjust_directory);
 	p.add("lyrics_directory", &lyrics_directory, "~/.lyrics/", adjust_directory);
 	p.add<void>("mpd_host", nullptr, "localhost", [](std::string host) {
 			expand_home(host);

--- a/src/settings.h
+++ b/src/settings.h
@@ -58,6 +58,7 @@ struct Configuration
 	bool read(const std::vector<std::string> &config_paths, bool ignore_errors);
 
 	std::string ncmpcpp_directory;
+	std::string log_directory;
 	std::string lyrics_directory;
 
 	std::string mpd_music_dir;


### PR DESCRIPTION
These commit add the `log_directory` option to the ncmpcpp configuration, which allows the user to set the location of `error.log` independently from `ncmpcpp_directory`.

If `log_directory` is not specified, `error.log` will be stored into `$XDG_DATA_HOME/ncmpcpp` (note that unfortunately, the [XDG base directory specification][1] does not mention log files at all).

This commit is just a proposal. I would like to have some feedback on which default value for `log_directory` makes most sense:

1. `$XDG_DATA_HOME/ncmpcpp/error.log` [current]: Treat logs like regular data/state files (see issue #110).
2. `$XDG_CACHE_HOME/ncmpcpp/error.log`: Treat logs like cache files (this is semantically incorrect IMHO, but there are people who might still argue for this).
2. `$XDG_LOG_HOME/ncmpcpp/error.log`: Note that `$XDG_LOG_HOME` is non-standard. However, some people seem to set and use it (even though [not very uniformly][2]). We would certainly need to agree on a default value for this.

**P.S.**
~~With this change, it appears that `ncmpcpp_directory` is no longer used for anything, also since the location for the `bindings` file respects `$XDG_CONFIG_HOME` now ([pull request 165][3]). Is it safe to remove `ncmpcpp_directory`?~~
Nevermind, I didn't see the tag editor.

[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
[2]: https://encrypted.google.com/search?hl=en&q=%22XDG_LOG_HOME%22#q=%22XDG_LOG_HOME%22&hl=en&filter=0
[3]: https://github.com/arybczak/ncmpcpp/pull/165