### PR TITLE
Fix crash when colors are disabled

### DIFF
--- a/src/curses/window.cpp
+++ b/src/curses/window.cpp
@@ -214,6 +214,10 @@ Color Color::End(0, 0, false, true);
 
 int Color::pairNumber() const
 {
+	// Fallback if color is unavailable
+	if (color_pair_map.empty())
+		return 0;
+
 	int result = 0;
 	if (isEnd())
 		throw std::logic_error("'end' doesn't have a corresponding pair number");


### PR DESCRIPTION
Fix #218 

Even if color is not available or disabled manually, the coloring code in `NC::Window` still tries to set the color. To obtain a pair number to pass to the ncurses API, the coloring code calls `Color::pairNumber`. However, `COLORS` exported by ncurses is 0 because coloring support hasn't been initialized yet, which results in divide-by-zero error.

This fix is lazy. Instead of patching all coloring code, it returns a fallback pair number to the caller -- color support hasn't been enabled yet, and the color-setting call to ncurses will fail silently.

I'm not sure whether this is the desired way. Patching all coloring code is another option, but it's probable that further development neglects the check. The PR in question solves the problem from a lower level. You can write code that use colors as you want, and ncurses will ignore it anyway.