### PR TITLE
tag_editor.cpp: Fix misleading indentation

### DIFF
--- a/src/screens/tag_editor.cpp
+++ b/src/screens/tag_editor.cpp
@@ -1062,7 +1062,7 @@ void GetPatternList()
 			while (std::getline(input, line))
 				if (!line.empty())
 					Patterns.push_back(line);
-				input.close();
+			input.close();
 		}
 	}
 }
@@ -1164,14 +1164,14 @@ std::string ParseFilename(MPD::MutableSong &s, std::string mask, bool preview)
 			if (*j == '_')
 				*j = ' ';
 			
-			if (!preview)
-			{
-				MPD::MutableSong::SetFunction set = IntoSetFunction(it->first);
-				if (set)
-					s.setTags(set, it->second);
-			}
-			else
-				result << "%" << it->first << ": " << it->second << "\n";
+		if (!preview)
+		{
+			MPD::MutableSong::SetFunction set = IntoSetFunction(it->first);
+			if (set)
+				s.setTags(set, it->second);
+		}
+		else
+			result << "%" << it->first << ": " << it->second << "\n";
 	}
 	return result.str();
 }


### PR DESCRIPTION
Prior to this commit GCC 6.3.1 throws 2 warnings on lines 1062 and 1161 if `ncmpcpp` is compiled with `-Wmisleading-indentation` and `--with-taglib`.
The code blocks mentioned in the related notes seem to be indented one tab too much.