### PR TITLE
ncmpcpp.1: Fix indentation

### DIFF
--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -41,7 +41,7 @@ Display help.
 .TP
 .B \-v, \-\-version
 Display version information.
-.TP
+
 .SH "CONFIGURATION"
 When ncmpcpp starts, it tries to read user's settings from $HOME/.ncmpcpp/config and $XDG_CONFIG_HOME/ncmpcpp/config files. If no configuration is found, ncmpcpp uses its default configuration. An example configuration file containing all default values is provided with ncmpcpp and can be usually found in /usr/share/doc/ncmpcpp (exact location may depend on used distribution or configure prefix).
 


### PR DESCRIPTION
The whole page from the "CONFIGURATION" header to the end is indented by an extraneous tab due to a redundant `.TP` directive.