### PR TITLE
Lexically order songs in media library if track numbers are equal

### DIFF
--- a/src/screens/media_library.cpp
+++ b/src/screens/media_library.cpp
@@ -115,12 +115,22 @@ public:
 			if (ret != 0)
 				return ret < 0;
 		}
-		try {
-			int ret = boost::lexical_cast<int>(a.getTags(&MPD::Song::getTrackNumber))
-			        - boost::lexical_cast<int>(b.getTags(&MPD::Song::getTrackNumber));
-			return ret < 0;
-		} catch (boost::bad_lexical_cast &) {
-			return a.getTrackNumber() < b.getTrackNumber();
+		// Sort by track number if track numbers are different
+		if( a.getTags(&MPD::Song::getTrackNumber) != b.getTags(&MPD::Song::getTrackNumber) ) {
+			try {
+				int ret = boost::lexical_cast<int>(a.getTags(&MPD::Song::getTrackNumber))
+					- boost::lexical_cast<int>(b.getTags(&MPD::Song::getTrackNumber));
+
+				// If track numbers are equal, fall back to lexical ordering of track name.
+				if( ret != 0 ) 
+					return ret < 0;
+			} catch (boost::bad_lexical_cast &) {
+				return a.getTrackNumber() < b.getTrackNumber();
+			}
+		}
+		// Otherwise fall back to lexical sorting of track names.
+		else {
+				return a.getTags(&MPD::Song::getName) < b.getTags(&MPD::Song::getName);
 		}
 	}
 };


### PR DESCRIPTION
This aims to fix arybczak/ncmpcpp#231 by falling back to ordering songs lexically if songs' track numbers are equal. It's a fairly simple change -- there's a new test for equality of track numbers; if that fails then the original ordering based on TrackNumber is calculated, otherwise the ordering is based on the Name tag.

I've tested this against my (fairly substantial) media library. As far as I can tell, it works. Albums with track numbers remain sorted as before, but my podcasts -- which don't typically contain track numbers -- are now sorted by track name.