### PR TITLE
Clear search constraint in find and add 'append_search_constraint' option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ ncmpcpp-0.8.1 (????-??-??)
 * Using '--quiet' command line argument no longer results in a crash.
 * If songs in media library have no track numbers, sort them by their display format.
 * Fixed a situation in which songs added to playlist from media library or playlist editor screens would not be immediately marked as such.
+* Search constraint in find is now clear by default. Configuration variable 'append_search_constraint' can be enabled to restore previous behavior.
 
 ncmpcpp-0.8 (2017-05-21)
 * Configuration variable 'execute_on_player_state_change' was added.

--- a/doc/config
+++ b/doc/config
@@ -442,6 +442,8 @@
 #
 #block_search_constraints_change_if_items_found = yes
 #
+#append_search_constraint = no
+#
 #mouse_support = yes
 #
 #mouse_list_scroll_whole_page = yes

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -333,6 +333,9 @@ If enabled, diacritics in strings will be ignored while searching and filtering 
 .B block_search_constraints_change_if_items_found = yes/no
 If enabled, fields in Search engine above "Reset" button will be blocked after successful searching, otherwise they won't.
 .TP
+.B append_search_constraint = yes/no
+If enabled, your last search constraint will be appended next time you perform a find.
+.TP
 .B mouse_support = yes/no
 If set to yes, mouse support will be enabled.
 .TP

--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -3020,7 +3020,11 @@ void findItem(const SearchDirection direction)
 	assert(w != nullptr);
 	assert(w->allowsSearching());
 	
-	std::string constraint = w->searchConstraint();
+	std::string constraint;
+	
+	if (Config.append_search_constraint)
+		constraint = w->searchConstraint();
+	
 	try
 	{
 		ScopedValue<bool> disabled_autocenter_mode(Config.autocenter_mode, false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -541,6 +541,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("ignore_diacritics", &ignore_diacritics, "no", yes_no);
 	p.add("block_search_constraints_change_if_items_found",
 	      &block_search_constraints_change, "yes", yes_no);
+	p.add("append_search_constraint", &append_search_constraint, "no", yes_no);
 	p.add("mouse_support", &mouse_support, "yes", yes_no);
 	p.add("mouse_list_scroll_whole_page", &mouse_list_scroll_whole_page, "yes", yes_no);
 	p.add("empty_tag_marker", &empty_tag, "<empty>");

--- a/src/settings.h
+++ b/src/settings.h
@@ -158,6 +158,7 @@ struct Configuration
 	bool ignore_leading_the;
 	bool ignore_diacritics;
 	bool block_search_constraints_change;
+	bool append_search_constraint;
 	bool use_console_editor;
 	bool use_cyclic_scrolling;
 	bool ask_before_clearing_playlists;


### PR DESCRIPTION
Most popular ncurses programs don't append your last inputted search constraint when doing a quick search with "/". This change addresses the complaints in issue #221 by clearing the input by default and adds a 'append_search_constraint' option which you can enable if you wish to keep the previous behavior.