### PR TITLE
Add support for starting playback in stopped state

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -804,6 +804,11 @@ void NextSong::run()
 	Mpd.Next();
 }
 
+bool Pause::canBeRun()
+{
+	return Status::State::player() != MPD::psStop;
+}
+
 void Pause::run()
 {
 	Mpd.Toggle();
@@ -843,6 +848,11 @@ void SavePlaylist::run()
 void Stop::run()
 {
 	Mpd.Stop();
+}
+
+void Play::run()
+{
+	Mpd.Play();
 }
 
 void ExecuteCommand::run()
@@ -2734,6 +2744,7 @@ void populateActions()
 	insert_action(new Actions::NextSong());
 	insert_action(new Actions::Pause());
 	insert_action(new Actions::Stop());
+	insert_action(new Actions::Play());
 	insert_action(new Actions::ExecuteCommand());
 	insert_action(new Actions::SavePlaylist());
 	insert_action(new Actions::MoveSortOrderUp());

--- a/src/actions.h
+++ b/src/actions.h
@@ -68,6 +68,7 @@ enum class Type
 	Next,
 	Pause,
 	Stop,
+	Play,
 	ExecuteCommand,
 	SavePlaylist,
 	MoveSortOrderUp,
@@ -515,12 +516,21 @@ struct Pause: BaseAction
 	Pause(): BaseAction(Type::Pause, "pause") { }
 	
 private:
+	virtual bool canBeRun() override;
 	virtual void run() override;
 };
 
 struct Stop: BaseAction
 {
 	Stop(): BaseAction(Type::Stop, "stop") { }
+	
+private:
+	virtual void run() override;
+};
+
+struct Play: BaseAction
+{
+	Play(): BaseAction(Type::Play, "play") { }
 	
 private:
 	virtual void run() override;


### PR DESCRIPTION
Right now sending the 'pause/resume' command to MPD if you are in the stopped state won't do anything, which is annoying since you have to switch to the playlist first.
With the 'play' action you can now do something like
```
def_key "space"
  pause
def_key "space"
  play
```
, and have a single keybinging for resuming or starting playing. Hopefully this is ok!

This would probably resolve https://github.com/arybczak/ncmpcpp/issues/197 as well.