### PR TITLE
Add option to hide album dates

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -335,6 +335,8 @@
 #
 #media_library_albums_split_by_date = yes
 #
+#media_library_hide_album_dates = no
+#
 ## Available values: wrapped, normal.
 ##
 #default_find_mode = wrapped

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -236,6 +236,9 @@ Default tag type for leftmost column in media library.
 .B media_library_albums_split_by_date = yes/no
 Determines whether albums in media library should be split by date.
 .TP
+.B media_library_hide_album_dates = yes/no
+Determines whether album dates in media library should be hidden.
+.TP
 .B default_find_mode = wrapped/normal
 If set to "wrapped", going from last found position to next will take you to the first one (same goes for the first position and going to previous one), otherwise no actions will be performed.
 .TP

--- a/src/screens/media_library.cpp
+++ b/src/screens/media_library.cpp
@@ -1076,7 +1076,7 @@ std::string AlbumToString(const AlbumEntry &ae)
 				result += ae.entry().tag();
 			result += " - ";
 		}
-		if (Config.media_lib_primary_tag != MPD_TAG_DATE && !ae.entry().date().empty())
+		if (Config.media_lib_primary_tag != MPD_TAG_DATE && !Config.media_lib_hide_album_dates && !ae.entry().date().empty())
 			result += "(" + ae.entry().date() + ") ";
 		result += ae.entry().album().empty() ? "<no album>" : ae.entry().album();
 	}

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -429,6 +429,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	});
 	p.add("user_interface", &design, "classic");
 	p.add("data_fetching_delay", &data_fetching_delay, "yes", yes_no);
+	p.add("media_library_hide_album_dates", &media_lib_hide_album_dates, "no", yes_no);
 	p.add("media_library_primary_tag", &media_lib_primary_tag, "artist", [](std::string v) {
 			if (v == "artist")
 				return MPD_TAG_ARTIST;

--- a/src/settings.h
+++ b/src/settings.h
@@ -167,6 +167,7 @@ struct Configuration
 	bool visualizer_in_stereo;
 	bool data_fetching_delay;
 	bool media_library_sort_by_mtime;
+  bool media_lib_hide_album_dates;
 	bool tag_editor_extended_numeration;
 	bool discard_colors_if_item_is_selected;
 	bool store_lyrics_in_song_dir;


### PR DESCRIPTION
This addresses #248, adding an option `media_library_hide_album_dates` that defaults to "no", leaving the default behavior unchanged, and hides the dates next to the album titles in the media library when set to "yes".