### PR TITLE
Add support for OriginalDate tag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,7 @@ AC_CHECK_HEADERS([netinet/tcp.h netinet/in.h], , AC_MSG_ERROR(vital headers miss
 AC_CHECK_HEADERS([langinfo.h], , AC_MSG_WARN(locale detection disabled))
 
 # libmpdclient2
-PKG_CHECK_MODULES([libmpdclient], [libmpdclient >= 2.8], [
+PKG_CHECK_MODULES([libmpdclient], [libmpdclient >= 2.14], [
 	AC_SUBST(libmpdclient_CFLAGS)
 	AC_SUBST(libmpdclient_LIBS)
 	CPPFLAGS="$CPPFLAGS $libmpdclient_CFLAGS"
@@ -134,7 +134,7 @@ PKG_CHECK_MODULES([libmpdclient], [libmpdclient >= 2.8], [
 		AC_MSG_ERROR([missing mpd/client.h header])
 	)
 ],
-	AC_MSG_ERROR([libmpdclient >= 2.8 is required!])
+	AC_MSG_ERROR([libmpdclient >= 2.14 is required!])
 )
 
 # readline

--- a/doc/config
+++ b/doc/config
@@ -127,6 +127,7 @@
 ## %t - title
 ## %b - album
 ## %y - date
+## %Y - original date
 ## %n - track number (01/12 -> 01)
 ## %N - full track info (01/12 -> 01/12)
 ## %g - genre
@@ -329,7 +330,7 @@
 #
 #data_fetching_delay = yes
 #
-## Available values: artist, album_artist, date, genre, composer, performer.
+## Available values: artist, album_artist, date, original_date, genre, composer, performer.
 ##
 #media_library_primary_tag = artist
 #

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -230,7 +230,7 @@ Default user interface used by ncmpcpp at start.
 .B data_fetching_delay = yes/no
 If enabled, there will be a 250ms delay between refreshing position in media library or playlist editor and fetching appropriate data from MPD. This limits data fetched from the server and is particularly useful if ncmpcpp is connected to a remote host.
 .TP
-.B media_library_primary_tag = artist/album_artist/date/genre/composer/performer
+.B media_library_primary_tag = artist/album_artist/date/original_date/genre/composer/performer
 Default tag type for leftmost column in media library.
 .TP
 .B media_library_albums_split_by_date = yes/no
@@ -432,6 +432,7 @@ For song format you can use:
  %t - title
  %b - album
  %y - date
+ %Y - original date
  %n - track number (01/12 -> 01)
  %N - full track info (01/12 -> 01/12)
  %g - genre

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -57,6 +57,8 @@ const wchar_t *toColumnName(char c)
 			return L"Album";
 		case 'y':
 			return L"Date";
+		case 'Y':
+			return L"Original Date";
 		case 'n': case 'N':
 			return L"Track";
 		case 'g':

--- a/src/mutable_song.cpp
+++ b/src/mutable_song.cpp
@@ -59,6 +59,11 @@ std::string MutableSong::getDate(unsigned idx) const
 	return getTag(MPD_TAG_DATE, [this, idx](){ return Song::getDate(idx); }, idx);
 }
 
+std::string MutableSong::getOriginalDate(unsigned idx) const
+{
+	return getTag(MPD_TAG_ORIGINAL_DATE, [this, idx](){ return Song::getOriginalDate(idx); }, idx);
+}
+
 std::string MutableSong::getGenre(unsigned idx) const
 {
 	return getTag(MPD_TAG_GENRE, [this, idx](){ return Song::getGenre(idx); }, idx);
@@ -112,6 +117,11 @@ void MutableSong::setTrack(const std::string &value, unsigned idx)
 void MutableSong::setDate(const std::string &value, unsigned idx)
 {
 	replaceTag(MPD_TAG_DATE, Song::getDate(idx), value, idx);
+}
+
+void MutableSong::setOriginalDate(const std::string &value, unsigned idx)
+{
+	replaceTag(MPD_TAG_ORIGINAL_DATE, Song::getOriginalDate(idx), value, idx);
 }
 
 void MutableSong::setGenre(const std::string &value, unsigned idx)

--- a/src/mutable_song.h
+++ b/src/mutable_song.h
@@ -40,6 +40,7 @@ struct MutableSong : public Song
 	virtual std::string getAlbumArtist(unsigned idx = 0) const override;
 	virtual std::string getTrack(unsigned idx = 0) const override;
 	virtual std::string getDate(unsigned idx = 0) const override;
+	virtual std::string getOriginalDate(unsigned idx = 0) const override;
 	virtual std::string getGenre(unsigned idx = 0) const override;
 	virtual std::string getComposer(unsigned idx = 0) const override;
 	virtual std::string getPerformer(unsigned idx = 0) const override;
@@ -52,6 +53,7 @@ struct MutableSong : public Song
 	void setAlbumArtist(const std::string &value, unsigned idx = 0);
 	void setTrack(const std::string &value, unsigned idx = 0);
 	void setDate(const std::string &value, unsigned idx = 0);
+	void setOriginalDate(const std::string &value, unsigned idx = 0);
 	void setGenre(const std::string &value, unsigned idx = 0);
 	void setComposer(const std::string &value, unsigned idx = 0);
 	void setPerformer(const std::string &value, unsigned idx = 0);

--- a/src/screens/search_engine.cpp
+++ b/src/screens/search_engine.cpp
@@ -57,6 +57,7 @@ namespace {
 	"Performer",
 	"Genre",
 	"Date",
+	"Original Date",
 	"Comment"
 }};
 
@@ -157,6 +158,7 @@ const char *SearchEngine::ConstraintsNames[] =
 	"Performer",
 	"Genre",
 	"Date",
+	"Original Date",
 	"Comment"
 };
 
@@ -469,7 +471,9 @@ void SearchEngine::Search()
 		if (!itsConstraints[9].empty())
 			Mpd.AddSearch(MPD_TAG_DATE, itsConstraints[9]);
 		if (!itsConstraints[10].empty())
-			Mpd.AddSearch(MPD_TAG_COMMENT, itsConstraints[10]);
+			Mpd.AddSearch(MPD_TAG_ORIGINAL_DATE, itsConstraints[10]);
+		if (!itsConstraints[11].empty())
+			Mpd.AddSearch(MPD_TAG_COMMENT, itsConstraints[11]);
 		for (MPD::SongIterator s = Mpd.CommitSearchSongs(), end; s != end; ++s)
 			w.addItem(std::move(*s));
 		return;
@@ -527,6 +531,7 @@ void SearchEngine::Search()
 					|| Regex::search(s->getPerformer(), rx[0], Config.ignore_diacritics)
 					|| Regex::search(s->getGenre(), rx[0], Config.ignore_diacritics)
 					|| Regex::search(s->getDate(), rx[0], Config.ignore_diacritics)
+					|| Regex::search(s->getOriginalDate(), rx[0], Config.ignore_diacritics)
 					|| Regex::search(s->getComment(), rx[0], Config.ignore_diacritics);
 			if (found && !rx[1].empty())
 				found = Regex::search(s->getArtist(), rx[1], Config.ignore_diacritics);
@@ -547,7 +552,9 @@ void SearchEngine::Search()
 			if (found && !rx[9].empty())
 				found = Regex::search(s->getDate(), rx[9], Config.ignore_diacritics);
 			if (found && !rx[10].empty())
-				found = Regex::search(s->getComment(), rx[10], Config.ignore_diacritics);
+				found = Regex::search(s->getOriginalDate(), rx[10], Config.ignore_diacritics);
+			if (found && !rx[11].empty())
+				found = Regex::search(s->getComment(), rx[11], Config.ignore_diacritics);
 		}
 		else // match only if values are equal
 		{
@@ -562,6 +569,7 @@ void SearchEngine::Search()
 				|| !cmp(s->getPerformer(), itsConstraints[0])
 				|| !cmp(s->getGenre(), itsConstraints[0])
 				|| !cmp(s->getDate(), itsConstraints[0])
+				|| !cmp(s->getOriginalDate(), itsConstraints[0])
 				|| !cmp(s->getComment(), itsConstraints[0]);
 			
 			if (found && !itsConstraints[1].empty())
@@ -583,7 +591,9 @@ void SearchEngine::Search()
 			if (found && !itsConstraints[9].empty())
 				found = !cmp(s->getDate(), itsConstraints[9]);
 			if (found && !itsConstraints[10].empty())
-				found = !cmp(s->getComment(), itsConstraints[10]);
+				found = !cmp(s->getOriginalDate(), itsConstraints[10]);
+			if (found && !itsConstraints[11].empty())
+				found = !cmp(s->getComment(), itsConstraints[11]);
 		}
 		
 		if (any_found && found)

--- a/src/screens/search_engine.h
+++ b/src/screens/search_engine.h
@@ -147,7 +147,7 @@ private:
 	
 	static const char *SearchModes[];
 	
-	static const size_t ConstraintsNumber = 11;
+	static const size_t ConstraintsNumber = 12;
 	static const char *ConstraintsNames[];
 	std::string itsConstraints[ConstraintsNumber];
 	

--- a/src/screens/song_info.cpp
+++ b/src/screens/song_info.cpp
@@ -39,18 +39,19 @@ SongInfo *mySongInfo;
 
 const SongInfo::Metadata SongInfo::Tags[] =
 {
- { "Title",        &MPD::Song::getTitle,       &MPD::MutableSong::setTitle       },
- { "Artist",       &MPD::Song::getArtist,      &MPD::MutableSong::setArtist      },
- { "Album Artist", &MPD::Song::getAlbumArtist, &MPD::MutableSong::setAlbumArtist },
- { "Album",        &MPD::Song::getAlbum,       &MPD::MutableSong::setAlbum       },
- { "Date",         &MPD::Song::getDate,        &MPD::MutableSong::setDate        },
- { "Track",        &MPD::Song::getTrack,       &MPD::MutableSong::setTrack       },
- { "Genre",        &MPD::Song::getGenre,       &MPD::MutableSong::setGenre       },
- { "Composer",     &MPD::Song::getComposer,    &MPD::MutableSong::setComposer    },
- { "Performer",    &MPD::Song::getPerformer,   &MPD::MutableSong::setPerformer   },
- { "Disc",         &MPD::Song::getDisc,        &MPD::MutableSong::setDisc        },
- { "Comment",      &MPD::Song::getComment,     &MPD::MutableSong::setComment     },
- { 0,              0,                          0                                 }
+ { "Title",         &MPD::Song::getTitle,        &MPD::MutableSong::setTitle        },
+ { "Artist",        &MPD::Song::getArtist,       &MPD::MutableSong::setArtist       },
+ { "Album Artist",  &MPD::Song::getAlbumArtist,  &MPD::MutableSong::setAlbumArtist  },
+ { "Album",         &MPD::Song::getAlbum,        &MPD::MutableSong::setAlbum        },
+ { "Date",          &MPD::Song::getDate,         &MPD::MutableSong::setDate         },
+ { "Original Date", &MPD::Song::getOriginalDate, &MPD::MutableSong::setOriginalDate },
+ { "Track",         &MPD::Song::getTrack,        &MPD::MutableSong::setTrack        },
+ { "Genre",         &MPD::Song::getGenre,        &MPD::MutableSong::setGenre        },
+ { "Composer",      &MPD::Song::getComposer,     &MPD::MutableSong::setComposer     },
+ { "Performer",     &MPD::Song::getPerformer,    &MPD::MutableSong::setPerformer    },
+ { "Disc",          &MPD::Song::getDisc,         &MPD::MutableSong::setDisc         },
+ { "Comment",       &MPD::Song::getComment,      &MPD::MutableSong::setComment      },
+ { 0,               0,                           0                                  }
 };
 
 SongInfo::SongInfo()

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -436,6 +436,8 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 				return MPD_TAG_ALBUM_ARTIST;
 			else if (v == "date")
 				return MPD_TAG_DATE;
+			else if (v == "original_date")
+				return MPD_TAG_ORIGINAL_DATE;
 			else if (v == "genre")
 				return MPD_TAG_GENRE;
 			else if (v == "composer")

--- a/src/song.cpp
+++ b/src/song.cpp
@@ -160,6 +160,12 @@ std::string Song::getDate(unsigned idx) const
 	return get(MPD_TAG_DATE, idx);
 }
 
+std::string Song::getOriginalDate(unsigned idx) const
+{
+	assert(m_song);
+	return get(MPD_TAG_ORIGINAL_DATE, idx);
+}
+
 std::string Song::getGenre(unsigned idx) const
 {
 	assert(m_song);

--- a/src/song.h
+++ b/src/song.h
@@ -65,6 +65,7 @@ struct Song
 	virtual std::string getTrack(unsigned idx = 0) const;
 	virtual std::string getTrackNumber(unsigned idx = 0) const;
 	virtual std::string getDate(unsigned idx = 0) const;
+	virtual std::string getOriginalDate(unsigned idx = 0) const;
 	virtual std::string getGenre(unsigned idx = 0) const;
 	virtual std::string getComposer(unsigned idx = 0) const;
 	virtual std::string getPerformer(unsigned idx = 0) const;

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -164,6 +164,7 @@ void writeID3v2Tags(const MPD::MutableSong &s, TagLib::ID3v2::Tag *tag)
 	writeID3v2("TPE2", tagList(s, &MPD::Song::getAlbumArtist));
 	writeID3v2("TALB", tagList(s, &MPD::Song::getAlbum));
 	writeID3v2("TDRC", tagList(s, &MPD::Song::getDate));
+	writeID3v2("TDOR", tagList(s, &MPD::Song::getOriginalDate));
 	writeID3v2("TRCK", tagList(s, &MPD::Song::getTrack));
 	writeID3v2("TCON", tagList(s, &MPD::Song::getGenre));
 	writeID3v2("TCOM", tagList(s, &MPD::Song::getComposer));
@@ -192,6 +193,7 @@ void writeXiphComments(const MPD::MutableSong &s, TagLib::Ogg::XiphComment *tag)
 	writeXiph("ALBUMARTIST", tagList(s, &MPD::Song::getAlbumArtist));
 	writeXiph("ALBUM", tagList(s, &MPD::Song::getAlbum));
 	writeXiph("DATE", tagList(s, &MPD::Song::getDate));
+	writeXiph("ORIGINALDATE", tagList(s, &MPD::Song::getOriginalDate));
 	writeXiph("TRACKNUMBER", tagList(s, &MPD::Song::getTrack));
 	writeXiph("GENRE", tagList(s, &MPD::Song::getGenre));
 	writeXiph("COMPOSER", tagList(s, &MPD::Song::getComposer));

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -88,6 +88,7 @@ void readID3v2Tags(mpd_song *s, TagLib::ID3v2::Tag *tag)
 	readFrame(frames["TPE2"], "AlbumArtist");
 	readFrame(frames["TALB"], "Album");
 	readFrame(frames["TDRC"], "Date");
+	readFrame(frames["TDOR"], "OriginalDate");
 	readFrame(frames["TRCK"], "Track");
 	readFrame(frames["TCON"], "Genre");
 	readFrame(frames["TCOM"], "Composer");
@@ -108,6 +109,7 @@ void readXiphComments(mpd_song *s, TagLib::Ogg::XiphComment *tag)
 	readField(fields["ALBUMARTIST"], "AlbumArtist");
 	readField(fields["ALBUM"], "Album");
 	readField(fields["DATE"], "Date");
+	readField(fields["ORIGINALDATE"], "OriginalDate");
 	readField(fields["TRACKNUMBER"], "Track");
 	readField(fields["GENRE"], "Genre");
 	readField(fields["COMPOSER"], "Composer");

--- a/src/utility/type_conversions.cpp
+++ b/src/utility/type_conversions.cpp
@@ -144,6 +144,8 @@ mpd_tag_type charToTagType(char c)
 			return MPD_TAG_ALBUM;
 		case 'y':
 			return MPD_TAG_DATE;
+		case 'Y':
+			return MPD_TAG_ORIGINAL_DATE;
 		case 'n':
 			return MPD_TAG_TRACK;
 		case 'g':
@@ -182,6 +184,8 @@ MPD::Song::GetFunction charToGetFunction(char c)
 			return &MPD::Song::getAlbum;
 		case 'y':
 			return &MPD::Song::getDate;
+		case 'Y':
+			return &MPD::Song::getOriginalDate;
 		case 'n':
 			return &MPD::Song::getTrackNumber;
 		case 'N':

--- a/src/utility/type_conversions.cpp
+++ b/src/utility/type_conversions.cpp
@@ -82,6 +82,8 @@ std::string tagTypeToString(mpd_tag_type tag)
 			return "Genre";
 		case MPD_TAG_DATE:
 			return "Date";
+		case MPD_TAG_ORIGINAL_DATE:
+			return "OriginalDate";
 		case MPD_TAG_COMPOSER:
 			return "Composer";
 		case MPD_TAG_PERFORMER:
@@ -113,6 +115,8 @@ MPD::MutableSong::SetFunction tagTypeToSetFunction(mpd_tag_type tag)
 			return &MPD::MutableSong::setGenre;
 		case MPD_TAG_DATE:
 			return &MPD::MutableSong::setDate;
+		case MPD_TAG_ORIGINAL_DATE:
+			return &MPD::MutableSong::setOriginalDate;
 		case MPD_TAG_COMPOSER:
 			return &MPD::MutableSong::setComposer;
 		case MPD_TAG_PERFORMER:
@@ -213,6 +217,8 @@ boost::optional<mpd_tag_type> getFunctionToTagType(MPD::Song::GetFunction f)
 		return MPD_TAG_TRACK;
 	else if (f == &MPD::Song::getDate)
 		return MPD_TAG_DATE;
+	else if (f == &MPD::Song::getOriginalDate)
+		return MPD_TAG_ORIGINAL_DATE;
 	else if (f == &MPD::Song::getGenre)
 		return MPD_TAG_GENRE;
 	else if (f == &MPD::Song::getComposer)


### PR DESCRIPTION
This adds support for the OriginalDate tag. The OriginalDate is supported by MPD since MusicPlayerDaemon/libmpdclient@e5d0e50 which added OriginalDate file tag support to libmpdclient.

The actual filetype dependent tag names are taken from the "Original Release Date" entry at: https://picard.musicbrainz.org/docs/mappings/

This also adds the `Y` char for OriginalDate tag columns (as opposed to `y` for the normal Date tag).

This resolves #244.

*Note:* ~~I wasn't able to properly test this yet. As soon as I tested it and everything seems to work I will remove the [WIP] prefix.~~ Tested and apparently works fine.