### PR TITLE
Restore curses after running external command

### DIFF
--- a/src/curses/window.cpp
+++ b/src/curses/window.cpp
@@ -443,6 +443,17 @@ void initScreen(bool enable_colors, bool enable_mouse)
 	rl_startup_hook = rl::add_base;
 }
 
+void pauseScreen()
+{
+	def_prog_mode();
+	endwin();
+}
+
+void unpauseScreen()
+{
+	refresh();
+}
+
 void destroyScreen()
 {
 	Mouse::disable();

--- a/src/curses/window.h
+++ b/src/curses/window.h
@@ -219,6 +219,12 @@ void disable();
 /// @param enable_colors enables colors
 void initScreen(bool enable_colors, bool enable_mouse);
 
+/// Pauses the screen (e.g. for running an external command)
+void pauseScreen();
+
+/// Unpauses the screen
+void unpauseScreen();
+
 /// Destroys the screen
 void destroyScreen();
 

--- a/src/macro_utilities.cpp
+++ b/src/macro_utilities.cpp
@@ -21,6 +21,7 @@
 #include "bindings.h"
 #include "global.h"
 #include "macro_utilities.h"
+#include "curses/window.h"
 #include "utility/string.h"
 #include "utility/wide_string.h"
 
@@ -87,7 +88,10 @@ RunExternalCommand::RunExternalCommand(std::string &&command)
 void RunExternalCommand::run()
 {
 	GNUC_UNUSED int res;
+
+	NC::pauseScreen();
 	res = std::system(m_command.c_str());
+	NC::unpauseScreen();
 }
 
 }


### PR DESCRIPTION
This allows running TUI tools like vim via run_external_command without
destroying the ncmpcpp curses output.

## Example

Add this to `~/.ncmpcpp/bindings`

```
def_command "test" [deferred]
  run_external_command "vim"
```

In `ncmpcpp`, run `:test`. Vim will be launched. Exit it (with `:q`).

Without this patch, `ncmpcpp` won't be displayed properly. With this patch applied, everything seems to work fine again.