### PR TITLE
Expand '~' in mpd_host when preceded by a password.

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -63,8 +63,12 @@ std::string xdg_config_home()
 void expand_home(std::string &path)
 {
 	assert(env_home != nullptr);
-	if (!path.empty() && path[0] == '~')
-		path.replace(0, 1, env_home);
+	if (!path.empty())
+	{
+		size_t i = path.find("~");
+		if (i != std::string::npos && (i == 0 || path[i - 1] == '@'))
+			path.replace(i, 1, env_home);
+	}
 }
 
 bool configure(int argc, char **argv)


### PR DESCRIPTION
Hello! This makes the tilda expand when mpd_host has both a password and points to a file: 'password@~/.mpd/socket'.