### PR TITLE
Embedded lyrics support for mp3 and FLAC

### DIFF
--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -174,7 +174,7 @@ LyricsFetcher::Result EmbeddedLyricFetcher::fetch(const std::string &filepath)
 			if (!frames.isEmpty()) {
 				auto *frame = dynamic_cast<TagLib::ID3v2::UnsynchronizedLyricsFrame *>(frames.front());
 				result.first = true;
-				lyrics = frame->text().to8Bit();
+				lyrics = frame->text().to8Bit(true);
 			}
 		}
 	} else if (auto flac_file = dynamic_cast<TagLib::FLAC::File *>(f.file())) {
@@ -182,7 +182,7 @@ LyricsFetcher::Result EmbeddedLyricFetcher::fetch(const std::string &filepath)
 			std::string tag_name = "LYRICS";
 			auto xiph = flac_file->xiphComment();
 			if (xiph->contains(tag_name)) {
-				lyrics = xiph->fieldListMap()[tag_name].front().to8Bit();
+				lyrics = xiph->fieldListMap()[tag_name].front().to8Bit(true);
 				result.first = true;
 			}
 		}

--- a/src/lyrics_fetcher.h
+++ b/src/lyrics_fetcher.h
@@ -28,11 +28,17 @@
 
 struct LyricsFetcher
 {
+	enum class FetchType {
+		URL,
+		FILENAME
+	};
+
 	typedef std::pair<bool, std::string> Result;
 
 	virtual ~LyricsFetcher() { }
 
 	virtual const char *name() const = 0;
+	virtual const FetchType type() const { return FetchType::URL; }
 	virtual Result fetch(const std::string &artist, const std::string &title);
 	
 protected:
@@ -52,6 +58,22 @@ typedef std::unique_ptr<LyricsFetcher> LyricsFetcher_;
 typedef std::vector<LyricsFetcher_> LyricsFetchers;
 
 std::istream &operator>>(std::istream &is, LyricsFetcher_ &fetcher);
+
+/**********************************************************************/
+
+struct EmbeddedLyricFetcher : public LyricsFetcher
+{
+	virtual const char *name() const override { return "embedded"; }
+	virtual const FetchType type() const { return FetchType::FILENAME; }
+
+	Result fetch(const std::string &filepath);
+
+protected:
+	virtual const char *urlTemplate() const override { return ""; }
+	virtual const char *regex() const override { return ""; }
+
+	virtual void postProcess(std::string &data) const override;
+};
 
 /**********************************************************************/
 

--- a/src/screens/lyrics.h
+++ b/src/screens/lyrics.h
@@ -92,6 +92,7 @@ private:
 	void stopDownload();
 
 	bool m_refresh_window;
+	bool m_save_lyrics;
 	size_t m_scroll_begin;
 
 	std::shared_ptr<Shared<NC::Buffer>> m_shared_buffer;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -462,7 +462,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("cyclic_scrolling", &use_cyclic_scrolling, "no", yes_no);
 	p.add("lines_scrolled", &lines_scrolled, "2");
 	p.add("lyrics_fetchers", &lyrics_fetchers,
-	      "lyricwiki, azlyrics, genius, sing365, lyricsmania, metrolyrics, justsomelyrics, jahlyrics, plyrics, tekstowo, internet",
+	      "embedded, lyricwiki, azlyrics, genius, sing365, lyricsmania, metrolyrics, justsomelyrics, jahlyrics, plyrics, tekstowo, internet",
 	      list_of<LyricsFetcher_>);
 	p.add("follow_now_playing_lyrics", &now_playing_lyrics, "no", yes_no);
 	p.add("fetch_lyrics_for_current_song_in_background", &fetch_lyrics_in_background,


### PR DESCRIPTION
Follow on from pull request #296 (credit to @abelmul).

mp3: Reads the first `USLT` frame from `id3v2` tags.
FLAC: Reads the first `lyrics` tag from `Vorbis comment` tags.

Renamed lyric_fetcher from `file` to `embedded` to improve clarity.

`UTF-8` should work. I've tested functionality with various Korean characters and emojis.