### PR TITLE
Pass lyrics filename in single quotes

### DIFF
--- a/src/screens/lyrics.cpp
+++ b/src/screens/lyrics.cpp
@@ -326,6 +326,7 @@ void Lyrics::edit()
 	GNUC_UNUSED int res;
 	std::string command;
 	std::string filename = lyricsFilename(m_song);
+	escapeSingleQuotes(filename);
 	if (Config.use_console_editor)
 	{
 		command = Config.external_editor + " '" + filename + "'";
@@ -337,7 +338,7 @@ void Lyrics::edit()
 	else
 	{
 		command = "nohup " + Config.external_editor
-			+ " \"" + filename + "\" > /dev/null 2>&1 &";
+			+ " '" + filename + "' > /dev/null 2>&1 &";
 		res = system(command.c_str());
 	}
 }

--- a/src/screens/lyrics.cpp
+++ b/src/screens/lyrics.cpp
@@ -328,7 +328,7 @@ void Lyrics::edit()
 	std::string filename = lyricsFilename(m_song);
 	if (Config.use_console_editor)
 	{
-		command = "/bin/sh -c \"" + Config.external_editor + " \\\"" + filename + "\\\"\"";
+		command = Config.external_editor + " '" + filename + "'";
 		NC::pauseScreen();
 		res = system(command.c_str());
 		NC::unpauseScreen();

--- a/src/utility/string.cpp
+++ b/src/utility/string.cpp
@@ -96,3 +96,15 @@ void removeInvalidCharsFromFilename(std::string &filename, bool win32_compatible
 		}
 	}
 }
+
+void escapeSingleQuotes(std::string &filename)
+{
+	for (size_t i = 0; i < filename.length(); ++i)
+	{
+		if (filename[i] == '\'')
+		{
+			filename.replace(i, 1, "'\\''");
+			i += 3;
+		}
+	}
+}

--- a/src/utility/string.h
+++ b/src/utility/string.h
@@ -60,4 +60,6 @@ std::string getEnclosedString(const std::string &s, char a, char b, size_t *pos)
 
 void removeInvalidCharsFromFilename(std::string &filename, bool win32_compatible);
 
+void escapeSingleQuotes(std::string &filename);
+
 #endif // NCMPCPP_UTILITY_STRING_H


### PR DESCRIPTION
Fixes #345.

I removed the `/bin/sh -c` part of the command for convenience and because it seemed superfluous, but is there some rationale for it that I'm not aware of?