### PR TITLE
Take album artists into account when adding random albums

### DIFF
--- a/src/mpdpp.cpp
+++ b/src/mpdpp.cpp
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <algorithm>
 #include <map>
+#include <random>
 #include <boost/regex.hpp>
 
 #include "charset.h"
@@ -590,14 +591,74 @@ bool Connection::AddRandomTag(mpd_tag_type tag, size_t number, std::mt19937 &rng
 	{
 		StartSearch(true);
 		AddSearch(tag, *it++);
-		std::vector<std::string> paths;
 		MPD::SongIterator s = CommitSearchSongs(), end;
-		for (; s != end; ++s)
-			paths.push_back(s->getURI());
-		StartCommandsList();
-		for (const auto &path : paths)
-			AddSong(path);
-		CommitCommandsList();
+		if (tag != MPD_TAG_ALBUM)
+		{
+			std::vector<std::string> paths;
+			for (; s != end; ++s)
+				paths.push_back(s->getURI());
+			StartCommandsList();
+			for (const auto &path : paths)
+				AddSong(path);
+			CommitCommandsList();
+		}
+		else
+		{
+			// Treat (album, album artist) as the identifier when picking albums.
+			// So pick a single album artist.
+			// Limitations of this approach:
+			// - The way this is done here makes it slightly less probable for an album
+			//   that shares its name with others to be picked, compared to an album that
+			//   has a unique name. This is an acceptable compromise, since ensuring equal
+			//   probabilities would require requesting data for all songs from MPD.
+			// - Albums with identical names count as only one album for the check
+			//   `numbers > tags.size()` above. This does not matter much.
+			// - If one album has album artist A, and another identically named  album has
+			//   album artists A, and B, then picking the first album will also add the
+			//   second album. This is very unlikely to happen in real life.
+			std::vector<Song> songs;
+			std::set<std::string> album_artists;
+			for (; s != end; ++s)
+			{
+				songs.push_back(*s);
+				for (unsigned idx = 0; ; ++idx)
+				{
+					std::string aa = s->getAlbumArtist(idx);
+					if (aa.empty())
+						break;
+					album_artists.insert(aa);
+				}
+			}
+			std::string selected_album_artist;
+			if (album_artists.size() > 1)
+			{
+				std::uniform_int_distribution<size_t> udist(0, album_artists.size() - 1);
+				auto aait = album_artists.begin();
+				std::advance(aait, udist(rng));
+				selected_album_artist = *aait;
+			}
+			StartCommandsList();
+			for (const auto &song : songs)
+			{
+				bool add = false;
+				if (album_artists.size() <= 1)
+					add = true;
+				else
+				{
+					for (unsigned idx = 0; !add; ++idx)
+					{
+						std::string aa = song.getAlbumArtist(idx);
+						if (aa.empty())
+							break;
+						if (aa == selected_album_artist)
+							add = true;
+					}
+				}
+				if (add)
+					AddSong(song.getURI());
+			}
+			CommitCommandsList();
+		}
 	}
 	return true;
 }


### PR DESCRIPTION
When adding a random album, the album artist intuitively should
be the same for all added songs. Currently, this is not so,
so when adding e.g. 'Greatest Hits' you can get many different albums.

Fix this by randomly selecting one album artist whose songs to add.
See comment inside the code for (insignificant) limitations.

Fixes Github issue #159.
This replaces pull request #198, since I some time ago deleted the repo that was based on.