### PR TITLE
Add ability to not display the "Connected to ..." message at startup

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -349,6 +349,9 @@
 #
 #statusbar_visibility = yes
 #
+## Show the "Connected to ..." message on startup
+#connected_message_on_startup = yes
+#
 #titles_visibility = yes
 #
 #header_text_scrolling = yes

--- a/doc/ncmpcpp.1
+++ b/doc/ncmpcpp.1
@@ -248,6 +248,9 @@ If enabled, header window will be displayed, otherwise hidden.
 .B statusbar_visibility = yes/no
 If enabled, statusbar will be displayed, otherwise hidden.
 .TP
+.B connected_message_on_startup = yes/no
+Show the "Connected to ..." message on startup
+.TP
 .B titles_visibility = yes/no
 If enabled, column titles will be displayed, otherwise hidden.
 .TP

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -458,6 +458,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("default_tag_editor_pattern", &pattern, "%n - %t");
 	p.add("header_visibility", &header_visibility, "yes", yes_no);
 	p.add("statusbar_visibility", &statusbar_visibility, "yes", yes_no);
+	p.add("connected_message_on_startup", &connected_message_on_startup, "yes", yes_no);
 	p.add("titles_visibility", &titles_visibility, "yes", yes_no);
 	p.add("header_text_scrolling", &header_text_scrolling, "yes", yes_no);
 	p.add("cyclic_scrolling", &use_cyclic_scrolling, "no", yes_no);

--- a/src/settings.h
+++ b/src/settings.h
@@ -140,6 +140,7 @@ struct Configuration
 	bool header_visibility;
 	bool header_text_scrolling;
 	bool statusbar_visibility;
+	bool connected_message_on_startup;
 	bool titles_visibility;
 	bool centered_cursor;
 	bool screen_switcher_previous;

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -169,7 +169,10 @@ void initialize_status()
 
 	m_status_initialized = true;
 	wFooter->addFDCallback(Mpd.GetFD(), Statusbar::Helpers::mpd);
-	Statusbar::printf("Connected to %1%", Mpd.GetHostname());
+	if (Config.connected_message_on_startup)
+	{
+		Statusbar::printf("Connected to %1%", Mpd.GetHostname());
+	}
 }
 
 }


### PR DESCRIPTION
I added the ability to not display the "Connected to ..." message at startup.
It can be annoying if you close and reopen multiple times ncmpcpp.