### PR TITLE
Curses: don't iterate through unbound COLORS #369

### DIFF
--- a/src/curses/window.h
+++ b/src/curses/window.h
@@ -219,6 +219,10 @@ void disable();
 /// @param enable_colors enables colors
 void initScreen(bool enable_colors, bool enable_mouse);
 
+// Get the maximum supported color index (but only once initScreen() has been
+// successfully called). This might be less than the advertised COLORS.
+int colorCount();
+
 /// Pauses the screen (e.g. for running an external command)
 void pauseScreen();
 

--- a/src/screens/help.cpp
+++ b/src/screens/help.cpp
@@ -424,8 +424,10 @@ void write_bindings(NC::Scrollpad &w)
 	}
 
 	section(w, "", "List of available colors");
-	for (int i = 0; i < COLORS; ++i)
+	for (int i = 0; i < NC::colorCount(); ++i)
+	{
 		w << NC::Color(i, NC::Color::transparent) << i+1 << NC::Color::End << " ";
+	}
 }
 
 }


### PR DESCRIPTION
On DirectColor-capable terminals with the proper terminfo
database in use, COLORS is 2^24. Since the color map is
only 64k entries, this resulted in a segfault. I've
introduced NC::colorCount(), which bounds it by the
previously assumed maximum (and usable range) of 256.