### PR TITLE
Stop using deprecated removeField method

### DIFF
--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -173,18 +173,17 @@ void writeID3v2Tags(const MPD::MutableSong &s, TagLib::ID3v2::Tag *tag)
 void writeXiphComments(const MPD::MutableSong &s, TagLib::Ogg::XiphComment *tag)
 {
 	auto writeXiph = [&](const TagLib::String &type, const TagLib::StringList &list) {
-		tag->removeField(type);
 		for (auto it = list.begin(); it != list.end(); ++it)
-			tag->addField(type, *it, false);
+			tag->addField(type, *it);
 	};
 	// remove field previously used as album artist
-	tag->removeField("ALBUM ARTIST");
+	tag->removeFields("ALBUM ARTIST");
 	// remove field TRACK, some taggers use it as TRACKNUMBER
-	tag->removeField("TRACK");
+	tag->removeFields("TRACK");
 	// remove field DISC, some taggers use it as DISCNUMBER
-	tag->removeField("DISC");
+	tag->removeFields("DISC");
 	// remove field DESCRIPTION, it's displayed as COMMENT
-	tag->removeField("DESCRIPTION");
+	tag->removeFields("DESCRIPTION");
 	writeXiph("TITLE", tagList(s, &MPD::Song::getTitle));
 	writeXiph("ARTIST", tagList(s, &MPD::Song::getArtist));
 	writeXiph("ALBUMARTIST", tagList(s, &MPD::Song::getAlbumArtist));


### PR DESCRIPTION
This will fix https://github.com/arybczak/ncmpcpp/issues/371

taglib deprecated removeField internally in [1], but did not add the
deprecation warning until about four years later. The original bug
report [2] and pull request commit both mention not wanting to change
the original method's behaviour, but this was done anyway (perhaps by
mistake) in [3].

With that change, removeField(type) will not remove all tags of the
given type anymore, as the default for value has changed from
String::null to String().

This commit replaces explicit calls to removeField(type) with
removeFields(type), which has the correct behaviour. In writeXiph,
removeField is removed entirely, as addField(key, value) will replace
the tag by default.

[1] https://github.com/taglib/taglib/pull/681
[2] https://github.com/taglib/taglib/issues/651
[3] https://github.com/taglib/taglib/commit/c05fa78406fd8ce7382a11c1f63a17c4bfbe83fa