### PR TITLE
disable default binds 

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -627,3 +627,14 @@
 #
 #active_window_border = red
 #
+## By default all default key bindings are loaded unless explicitly override in
+## local bindings in ~/.ncmpcpp/bindings or $XDG_CONFIG_HOME/ncmpcpp/bindings
+##
+## This config will disable that behaviour when set to no
+##
+## Note: with this config enabled it is required to have atlease one
+## key defined in bindings file
+## i.e ncmpcpp crashes if bindings file is empty or not found in expected
+## path
+# default_bindings = yes
+#

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -95,6 +95,7 @@ bool configure(int argc, char **argv)
 		("ignore-config-errors", "ignore unknown and invalid options in configuration files")
 		("test-lyrics-fetchers", "check if lyrics fetchers work")
 		("bindings,b", po::value<std::vector<std::string>>(&bindings_paths)->value_name("PATH")->default_value(default_bindings_paths, join<std::string>(default_bindings_paths, " AND ")), "specify bindings file(s)")
+		("no-default-bindings", "disable default keybindings")
 		("screen,s", po::value<std::string>()->value_name("SCREEN"), "specify the startup screen")
 		("slave-screen,S", po::value<std::string>()->value_name("SCREEN"), "specify the startup slave screen")
 		("help,?", "show help message")
@@ -195,7 +196,9 @@ bool configure(int argc, char **argv)
 		std::for_each(bindings_paths.begin(), bindings_paths.end(), expand_home);
 		if (Bindings.read(bindings_paths) == false)
 			exit(1);
-		Bindings.generateDefaults();
+		if (vm.count("no-default-bindings") == false ){
+			Bindings.generateDefaults();
+		}
 
 		// create directories
 		boost::filesystem::create_directories(Config.ncmpcpp_directory);
@@ -271,3 +274,4 @@ bool configure(int argc, char **argv)
 	}
 	return true;
 }
+

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -196,9 +196,9 @@ bool configure(int argc, char **argv)
 		std::for_each(bindings_paths.begin(), bindings_paths.end(), expand_home);
 		if (Bindings.read(bindings_paths) == false)
 			exit(1);
-		if (vm.count("no-default-bindings") == false ){
+
+		if ((vm.count("no-default-bindings") == false) && (Config.default_bindings == true))
 			Bindings.generateDefaults();
-		}
 
 		// create directories
 		boost::filesystem::create_directories(Config.ncmpcpp_directory);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -613,6 +613,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 	p.add("window_border_color", &window_border, "green", verbose_lexical_cast<NC::Color>);
 	p.add("active_window_border", &active_window_border, "red",
 	      verbose_lexical_cast<NC::Color>);
+	p.add("default_bindings", &default_bindings, "yes", yes_no);
 
 	return std::all_of(
 		config_paths.begin(),

--- a/src/settings.h
+++ b/src/settings.h
@@ -192,6 +192,7 @@ struct Configuration
 	bool allow_for_physical_item_deletion;
 	bool media_library_albums_split_by_date;
 	bool startup_slave_screen_focus;
+	bool default_bindings;
 
 	unsigned mpd_connection_timeout;
 	unsigned crossfade_time;


### PR DESCRIPTION
resolves #289
- i am not experienced with cpp 
- just looked at highlevel overview and made this patch
 
## Tested on Arch Linux 
- with the switch enabled ncmcpp crashes if the bindings file is empty or not found
- requires to atleast have one key defined to work

## working:
- cli flag `--no-default-bindings`
- config key `default_bindings` bool
