### PR TITLE
Add azlyrics and darklyrics fetchers

### DIFF
--- a/doc/config
+++ b/doc/config
@@ -422,7 +422,7 @@
 #
 #cyclic_scrolling = no
 #
-#lyrics_fetchers = tags, tekstowo, plyrics, justsomelyrics, jahlyrics, zeneszoveg, internet
+#lyrics_fetchers = tags, tekstowo, plyrics, justsomelyrics, jahlyrics, zeneszoveg, azlyrics, darklyrics, internet
 #
 #follow_now_playing_lyrics = no
 #

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -161,6 +161,10 @@ bool configure(int argc, char **argv)
 				std::make_tuple("plyrics", "rihanna", "umbrella"),
 				std::make_tuple("tekstowo", "rihanna", "umbrella"),
 				std::make_tuple("zeneszoveg", "rihanna", "umbrella"),
+				std::make_tuple("azlyrics", "rihanna", "umbrella"),
+				std::make_tuple("darklyrics", "agalloch", "falling snow"),
+				
+								
 			};
 			for (auto &data : fetcher_data)
 			{

--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -54,6 +54,10 @@ std::istream &operator>>(std::istream &is, LyricsFetcher_ &fetcher)
 		fetcher = std::make_unique<TekstowoFetcher>();
 	else if (s == "zeneszoveg")
 		fetcher = std::make_unique<ZeneszovegFetcher>();
+	else if (s == "azlyrics")
+		fetcher = std::make_unique<AzLyricsFetcher>();
+	else if (s == "darklyrics")
+		fetcher = std::make_unique<DarkLyricsFetcher>();
 	else if (s == "internet")
 		fetcher = std::make_unique<InternetLyricsFetcher>();
 #ifdef HAVE_TAGLIB_H
@@ -205,6 +209,42 @@ bool GoogleLyricsFetcher::isURLOk(const std::string &url)
 {
 	return url.find(siteKeyword()) != std::string::npos;
 }
+
+LyricsFetcher::Result DarkLyricsFetcher::fetch(const std::string &artist,
+                                               const std::string &title,
+                                               const MPD::Song &song)
+{
+	current_title = title;
+	return GoogleLyricsFetcher::fetch(artist, title, song);
+}
+void DarkLyricsFetcher::postProcess(std::string &data) const
+{
+	try {
+		// Escape any special regex characters in the song title
+		std::string escaped_title = boost::regex_replace(current_title, boost::regex("[.^$|()\\[\\]{}*+?\\\\]"), "\\\\$&");
+		
+		// Match the <h3> tag with the title, and capture EVERYTHING after it
+		std::string pattern = "(?is)<h3>.*?" + escaped_title + ".*?</h3>(.*)";
+		boost::regex rx(pattern);
+		boost::smatch match;
+		
+		if (boost::regex_search(data, match, rx)) {
+			std::string song_data = match[1].str(); 
+			
+			// Cut off the text as soon as the next song's <h3> tag starts
+			size_t next_h3 = song_data.find("<h3>");
+			if (next_h3 != std::string::npos) {
+				song_data = song_data.substr(0, next_h3);
+			}
+			
+			data = song_data;
+		}
+	} catch (...) {}
+	
+	// Pass it back to the default postProcess to strip the remaining HTML tags
+	LyricsFetcher::postProcess(data);
+}
+
 
 /**********************************************************************/
 

--- a/src/lyrics_fetcher.h
+++ b/src/lyrics_fetcher.h
@@ -111,6 +111,28 @@ protected:
 	virtual const char *regex() const override { return "<div class=\"lyrics-plain-text trans_original\">(.*?)</div>"; }
 };
 
+struct AzLyricsFetcher : public GoogleLyricsFetcher
+{
+	virtual const char *name() const override { return "azlyrics.com"; }
+protected:
+	virtual const char *regex() const override { return "(?s)<!-- Usage of azlyrics\\.com content.*?-->(.*?)</div>"; }
+};
+
+struct DarkLyricsFetcher : public GoogleLyricsFetcher
+{
+	virtual const char *name() const override { return "darklyrics.com"; }
+	virtual Result fetch(const std::string &artist, const std::string &title, const MPD::Song &song) override;
+
+protected:
+	virtual const char *regex() const override { 
+		return "(?s)<div class=\"lyrics\">(.*?)(?:<div class=\"thanks\"|<div class=\"note\"|</div>)"; 
+	}
+	virtual void postProcess(std::string &data) const override;
+
+private:
+	std::string current_title;
+};
+
 struct InternetLyricsFetcher : public GoogleLyricsFetcher
 {
 	virtual const char *name() const override { return "the Internet"; }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -465,7 +465,7 @@ bool Configuration::read(const std::vector<std::string> &config_paths, bool igno
 #ifdef HAVE_TAGLIB_H
 	      "tags, "
 #endif
-	      "tekstowo, plyrics, justsomelyrics, jahlyrics, zeneszoveg, internet", [this](std::string v) {
+	      "tekstowo, plyrics, justsomelyrics, jahlyrics, zeneszoveg, azlyrics, darklyrics, internet", [this](std::string v) {
 		      lyrics_fetchers = list_of<LyricsFetcher_>(v, [](std::string s) {
 			      LyricsFetcher_ fetcher;
 			      try {


### PR DESCRIPTION
Adding two new lyrics sources from:

azlyrics.com and
darklyrics.com: A popular source for metal. Since DarkLyrics hosts full albums on a single page, I added a custom fetch and postProcess override to regex-match the specific song title and extract only the relevant lyrics from the album page.

Note: I am new to C++ and programming in general. Used an AI assistant (Gemini 3) to help me writing regex and structure the DarkLyricsFetcher logic. I have tested it locally and seem to fetch lyrics without issues. Thank you!