### PR TITLE
Fix crash in TinyTagEditor::runAction() with files without extensions

### DIFF
--- a/src/screens/tiny_tag_editor.cpp
+++ b/src/screens/tiny_tag_editor.cpp
@@ -145,8 +145,12 @@ void TinyTagEditor::runAction()
 		Statusbar::put() << NC::Format::Bold << "Filename: " << NC::Format::NoBold;
 		std::string filename = itsEdited.getNewName().empty() ? itsEdited.getName() : itsEdited.getNewName();
 		size_t dot = filename.rfind(".");
-		std::string extension = filename.substr(dot);
-		filename = filename.substr(0, dot);
+		std::string extension;
+		if (dot != std::string::npos)
+		{
+			extension = filename.substr(dot);
+			filename = filename.substr(0, dot);
+		}
 		std::string new_name = Global::wFooter->prompt(filename);
 		if (!new_name.empty())
 		{


### PR DESCRIPTION
When a user opens the Tiny Tag Editor for a song without a file extension and selects the "Filename" option (option 20), ncmpcpp crashes.

The issue occurs in the code that splits the filename into a base name and extension:

```cpp
size_t dot = filename.rfind(".");
std::string extension = filename.substr(dot);  // CRASH if dot == npos
filename = filename.substr(0, dot);             // OK - npos returns whole string
```

If the filename doesn't contain a '.', `rfind(".")` returns `std::string::npos`, and calling `substr(npos)` throws `std::out_of_range`, causing the crash. This affects files without extensions and stream URIs.

The fix checks if `dot != std::string::npos` before attempting to extract the extension:

```cpp
std::string extension;
if (dot != std::string::npos)
{
    extension = filename.substr(dot);
    filename = filename.substr(0, dot);
}
```