### PR TITLE
Replace non-standard Variable-Length Arrays with std::vector in Visualizer

### DIFF
--- a/src/screens/visualizer.cpp
+++ b/src/screens/visualizer.cpp
@@ -33,6 +33,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <cassert>
+#include <vector>
 
 #include "global.h"
 #include "settings.h"
@@ -219,7 +220,7 @@ void Visualizer::update()
 	if (Config.visualizer_in_stereo)
 	{
 		auto chan_samples = m_rendered_samples.size()/2;
-		int16_t buf_left[chan_samples], buf_right[chan_samples];
+		std::vector<int16_t> buf_left(chan_samples), buf_right(chan_samples);
 		for (size_t i = 0, j = 0; i < m_rendered_samples.size(); i += 2, ++j)
 		{
 			buf_left[j] = m_rendered_samples[i];
@@ -227,7 +228,7 @@ void Visualizer::update()
 		}
 		size_t half_height = w.getHeight()/2;
 
-		(this->*drawStereo)(buf_left, buf_right, chan_samples, half_height);
+		(this->*drawStereo)(buf_left.data(), buf_right.data(), chan_samples, half_height);
 	}
 	else
 	{


### PR DESCRIPTION
I accidentally included the commit for my other PR in this one, so I had to remake it, sorry.

In `Visualizer::update()` with stereo mode enabled, the code uses C99 Variable-Length Arrays (VLAs) to allocate audio buffers on the stack:

```cpp
auto chan_samples = m_rendered_samples.size() / 2;
int16_t buf_left[chan_samples], buf_right[chan_samples];
```

VLAs aren't part of the C++ standard. Buffer sizes range from ~29 KB per buffer (wave modes) to ~57 KB per buffer (spectrum mode), totaling ~114 KB for both. This approaches or exceeds default stack limits on some platforms (256 KB on Windows, smaller on embedded), potentially causing silent stack overflow crashes.

Using `std::vector` instead allocates on the heap and is standard C++:

```cpp
std::vector<int16_t> buf_left(chan_samples), buf_right(chan_samples);
```

Pass buffers to drawing functions using `.data()`:

```cpp
(this->*drawStereo)(buf_left.data(), buf_right.data(), chan_samples, half_height);
```

Also adds `#include <vector>`.