### PR TITLE
Fix path traversal in tag writer and read sinks via MPD song URI

### DIFF
--- a/src/actions.cpp
+++ b/src/actions.cpp
@@ -1509,7 +1509,7 @@ void EditLibraryAlbum::run()
 		for (size_t i = 0;  i < myLibrary->Songs.size(); ++i)
 		{
 			Statusbar::printf("Updating tags in \"%1%\"...", myLibrary->Songs[i].value().getName());
-			std::string path = Config.mpd_music_dir + myLibrary->Songs[i].value().getURI();
+			std::string path = Config.mpd_music_dir + normalizePath(myLibrary->Songs[i].value().getURI());
 			TagLib::FileRef f(path.c_str());
 			if (f.isNull())
 			{
@@ -1566,11 +1566,11 @@ void EditDirectoryName::run()
 			std::string full_old_dir;
 			if (!myBrowser->isLocal())
 				full_old_dir += Config.mpd_music_dir;
-			full_old_dir += old_dir;
+			full_old_dir += normalizePath(old_dir);
 			std::string full_new_dir;
 			if (!myBrowser->isLocal())
 				full_new_dir += Config.mpd_music_dir;
-			full_new_dir += new_dir;
+			full_new_dir += normalizePath(new_dir);
 			boost::filesystem::rename(full_old_dir, full_new_dir);
 			const char msg[] = "Directory renamed to \"%1%\"";
 			Statusbar::printf(msg, wideShorten(new_dir, COLS-const_strlen(msg)));
@@ -1590,8 +1590,8 @@ void EditDirectoryName::run()
 		}
 		if (!new_dir.empty() && new_dir != old_dir)
 		{
-			std::string full_old_dir = Config.mpd_music_dir + myTagEditor->CurrentDir() + "/" + old_dir;
-			std::string full_new_dir = Config.mpd_music_dir + myTagEditor->CurrentDir() + "/" + new_dir;
+			std::string full_old_dir = Config.mpd_music_dir + normalizePath(myTagEditor->CurrentDir() + "/" + old_dir);
+			std::string full_new_dir = Config.mpd_music_dir + normalizePath(myTagEditor->CurrentDir() + "/" + new_dir);
 			if (rename(full_old_dir.c_str(), full_new_dir.c_str()) == 0)
 			{
 				const char msg[] = "Directory renamed to \"%1%\"";

--- a/src/lyrics_fetcher.cpp
+++ b/src/lyrics_fetcher.cpp
@@ -237,7 +237,7 @@ LyricsFetcher::Result TagsLyricsFetcher::fetch([[maybe_unused]] const std::strin
 	std::string path;
 	if (song.isFromDatabase())
 		path += Config.mpd_music_dir;
-	path += song.getURI();
+	path += normalizePath(song.getURI());
 
 	TagLib::FileRef f(path.c_str());
 	if (f.isNull())

--- a/src/screens/song_info.cpp
+++ b/src/screens/song_info.cpp
@@ -25,6 +25,7 @@
 #include "tags.h"
 #include "title.h"
 #include "screens/screen_switcher.h"
+#include "utility/string.h"
 
 #ifdef HAVE_TAGLIB_H
 # include "fileref.h"
@@ -120,7 +121,7 @@ void SongInfo::PrepareSong(const MPD::Song &s)
 		std::string path_to_file;
 		if (s.isFromDatabase())
 			path_to_file += Config.mpd_music_dir;
-		path_to_file += s.getURI();
+		path_to_file += normalizePath(s.getURI());
 		TagLib::FileRef f(path_to_file.c_str());
 		if (!f.isNull())
 		{

--- a/src/screens/tiny_tag_editor.cpp
+++ b/src/screens/tiny_tag_editor.cpp
@@ -198,7 +198,7 @@ bool TinyTagEditor::getTags()
 	std::string path_to_file;
 	if (itsEdited.isFromDatabase())
 		path_to_file += Config.mpd_music_dir;
-	path_to_file += itsEdited.getURI();
+	path_to_file += normalizePath(itsEdited.getURI());
 	
 	TagLib::FileRef f(path_to_file.c_str());
 	if (f.isNull())

--- a/src/tags.cpp
+++ b/src/tags.cpp
@@ -296,7 +296,7 @@ bool write(MPD::MutableSong &s)
 	std::string old_name;
 	if (s.isFromDatabase())
 		old_name += Config.mpd_music_dir;
-	old_name += s.getURI();
+	old_name += normalizePath(s.getURI());
 	
 	TagLib::FileRef f(old_name.c_str());
 	if (f.isNull())
@@ -330,9 +330,9 @@ bool write(MPD::MutableSong &s)
 		std::string new_name;
 		if (s.isFromDatabase())
 			new_name += Config.mpd_music_dir;
-		new_name += s.getDirectory();
+		new_name += normalizePath(s.getDirectory());
 		new_name += "/";
-		new_name += s.getNewName();
+		new_name += normalizePath(s.getNewName());
 		boost::filesystem::rename(old_name, new_name);
 	}
 	return true;

--- a/src/utility/string.cpp
+++ b/src/utility/string.cpp
@@ -21,6 +21,9 @@
 #include <cassert>
 #include <cwctype>
 #include <algorithm>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
 #include "utility/string.h"
 
 std::string getBasename(const std::string &path)
@@ -107,4 +110,28 @@ void escapeSingleQuotes(std::string &filename)
 			i += 3;
 		}
 	}
+}
+
+std::string normalizePath(const std::string &path)
+{
+	std::vector<std::string> parts;
+	boost::split(parts, path, boost::is_any_of("/"));
+	bool absolute = !path.empty() && path[0] == '/';
+	std::vector<std::string> kept;
+	for (auto &part : parts)
+	{
+		if (part.empty() || part == ".")
+			continue;
+		if (part == "..")
+		{
+			if (!kept.empty())
+				kept.pop_back();
+			continue;
+		}
+		kept.push_back(std::move(part));
+	}
+	std::string result = boost::join(kept, "/");
+	if (absolute)
+		result = "/" + result;
+	return result;
 }

--- a/src/utility/string.h
+++ b/src/utility/string.h
@@ -61,4 +61,9 @@ void removeInvalidCharsFromFilename(std::string &filename, bool win32_compatible
 
 void escapeSingleQuotes(std::string &filename);
 
+// Collapse "." and ".." path segments. Relative paths cannot escape above
+// their root via ".."; absolute paths keep their leading slash. Used to
+// confine MPD-supplied URIs/directories under mpd_music_dir before joining.
+std::string normalizePath(const std::string &path);
+
 #endif // NCMPCPP_UTILITY_STRING_H


### PR DESCRIPTION
Tags::write built the on-disk path by concatenating mpd_music_dir with
the raw MPD song URI without filtering '..' segments, and
EditLibraryAlbum did the same with a direct TagLib::FileRef.
EditDirectoryName joined MPD-supplied directory paths with mpd_music_dir
the same way. A non-stream song whose URI contains '..' (served by a
remote or compromised MPD server) therefore resolved outside
mpd_music_dir: f.save() rewrote tags on an existing audio file at an
attacker-chosen path and, when the song was renamed,
boost::filesystem::rename moved the file.

The same mpd_music_dir + getURI pattern also appeared in read sinks:
TagsLyricsFetcher, the song info screen, and the tiny tag editor all
opened an arbitrary existing audio file at a traversed path with
TagLib::FileRef.

Add a shared normalizePath helper that collapses '.' and '..' segments
(relative paths cannot escape above their root, absolute paths keep
their leading slash) and apply it to every MPD-supplied URI/directory
before joining with mpd_music_dir. Legitimate relative URIs and
absolute local paths are unchanged; only traversal segments are removed.