### PR TITLE
Fix path traversal in browser delete via MPD path

### DIFF
--- a/src/screens/browser.cpp
+++ b/src/screens/browser.cpp
@@ -609,10 +609,48 @@ void Browser::fetchSupportedExtensions()
 
 namespace {
 
+// Collapse "." and ".." path segments so an MPD-supplied path cannot escape
+// mpd_music_dir via traversal. Relative paths cannot escape above their root
+// via ".."; absolute paths keep their leading slash.
+std::string normalizePath(const std::string &path)
+{
+	bool absolute = !path.empty() && path[0] == '/';
+	std::vector<std::string> kept;
+	size_t start = 0;
+	while (start <= path.length())
+	{
+		size_t end = path.find('/', start);
+		if (end == std::string::npos)
+			end = path.length();
+		std::string seg = path.substr(start, end - start);
+		if (!seg.empty() && seg != ".")
+		{
+			if (seg == "..")
+			{
+				if (!kept.empty())
+					kept.pop_back();
+			}
+			else
+				kept.push_back(seg);
+		}
+		start = end + 1;
+	}
+	std::string result;
+	for (size_t i = 0; i < kept.size(); ++i)
+	{
+		if (i)
+			result += "/";
+		result += kept[i];
+	}
+	if (absolute)
+		result = "/" + result;
+	return result;
+}
+
 std::string realPath(bool local_browser, std::string path)
 {
 	if (!local_browser)
-		path = Config.mpd_music_dir + path;
+		path = Config.mpd_music_dir + normalizePath(path);
 	return path;
 }
 


### PR DESCRIPTION
Browser::remove joined the raw MPD-supplied item path with mpd_music_dir
via realPath without filtering '..' segments, then called fs::remove. A
remote or compromised MPD server presenting a directory or song whose
path contains '..' could cause deletion of an arbitrary user-owned file
or directory outside mpd_music_dir when the user pressed delete in the
MPD browser. The confirmation prompt displays only the basename, so the
traversal was hidden from the user.

Add a local normalizePath helper in the anonymous namespace that
collapses '.' and '..' segments (relative paths cannot escape above
their root, absolute paths keep their leading slash) and apply it to the
MPD-supplied path inside realPath before joining with mpd_music_dir.
Legitimate relative paths are unchanged; only traversal segments are
removed.